### PR TITLE
Docker to use ci production and disable next telemetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,16 @@ FROM node:16.16.0-alpine3.16
 
 WORKDIR /usr/src/app
 
-COPY . ./
-# RUN npm install
-RUN npm ci && npm cache clean --force
+COPY package*.json ./
+RUN npm set-script prepare "" && npm ci --only=production && npm cache clean --force
 
+COPY . ./
 
 EXPOSE 8080
 
 ENV HOST=0.0.0.0
 ENV PORT=8080
+ENV NEXT_TELEMETRY_DISABLED=1
 
 RUN npm run build
 


### PR DESCRIPTION
## Changes 
- use ci --only-production flag
- fix husky issue when using production with set scripts 
- remove next js telemetry