### PR TITLE
Fix showing of login when user is already login

### DIFF
--- a/src/components/console/Login.js
+++ b/src/components/console/Login.js
@@ -21,11 +21,13 @@ const Login = () => {
   const handleLoginSuccess = (res) => {
     setloading(false);
 
-    setCookie(helpers.isProd ? 'APP_SID' : 'DEV_APP_SID', res.data.data);
     SuccessMsg({
       title: 'Success',
       action: () => {
-        window.location.reload();
+        setCookie(helpers.isProd ? 'APP_SID' : 'DEV_APP_SID', res.data.data);
+        setCookie('isAuthenticated', true);
+        setCookie('isUser', true);
+        window.location.replace('/instances');
       },
     });
   };

--- a/src/layouts/Main/Main.js
+++ b/src/layouts/Main/Main.js
@@ -14,9 +14,8 @@ import Container from 'components/Container';
 import TopNav from 'components/globals/TopNav';
 
 import { Topbar, Sidebar, Footer, AppNavigation } from './components';
-import { getUserAppSID } from 'utils';
 
-import { getCookie } from 'cookies-next';
+import { getCookie, setCookies } from 'cookies-next';
 import { useZestyStore } from 'store';
 
 const Main = ({
@@ -32,8 +31,8 @@ const Main = ({
   // main should verify the user as boolean
   const router = useRouter();
 
-  const instanceZUID = getCookie('ZESTY_WORKING_INSTANCE');
-  const userAppSID = getUserAppSID();
+  // const instanceZUID = getCookie('ZESTY_WORKING_INSTANCE');
+  // const userAppSID = getUserAppSID();
   const { verifySuccess, loading, userInfo } = useZestyStore((state) => state);
 
   const isAuthenticated = verifySuccess.userZuid ? true : false;
@@ -96,8 +95,12 @@ const Main = ({
 
   // store isUser isAuthenticated  in global state
   React.useEffect(() => {
-    setisAuthenticated(isAuthenticated);
-    setisUser(isUser);
+    if (isAuthenticated) {
+      setisAuthenticated(isAuthenticated);
+      setisUser(isUser);
+      setCookies('isAuthenticated', isAuthenticated);
+      setCookies('isUser', isUser);
+    }
   }, [isAuthenticated, isUser]);
 
   return (

--- a/src/pages/instances/index.js
+++ b/src/pages/instances/index.js
@@ -6,10 +6,13 @@ import { useZestyStore } from 'store';
 import Login from 'components/console/Login';
 import { InstancesDashboard } from 'components/accounts/instances/InstancesDashboard';
 import { useFetchWrapper } from 'components/hooks/useFetchWrapper';
+import { getCookie } from 'cookies-next';
 
 export default function Intances() {
   const { instances } = useFetchWrapper();
-  const { isAuthenticated, setInstances } = useZestyStore((state) => state);
+  const { setInstances } = useZestyStore((state) => state);
+
+  const isAuthenticated = getCookie('isAuthenticated');
 
   React.useEffect(() => {
     setInstances(instances);

--- a/src/pages/profile/index.js
+++ b/src/pages/profile/index.js
@@ -6,9 +6,10 @@ import { useZestyStore } from 'store';
 import Login from 'components/console/Login';
 import { YourProfile } from 'views/accounts/profile/YourProfile';
 import { ProfileApp } from 'components/accounts';
+import { getCookie } from 'cookies-next';
 
 export default function ProfilePage() {
-  const { isAuthenticated, setuserInfo } = useZestyStore((state) => state);
+  const { setuserInfo } = useZestyStore((state) => state);
   const { ZestyAPI } = useZestyStore((state) => state);
   const [userZUID, setuserZUID] = React.useState('');
 
@@ -39,6 +40,8 @@ export default function ProfilePage() {
     !res.error && handleGetUserSuccess(res);
     res.error && handleGetUserError(res);
   };
+
+  const isAuthenticated = getCookie('isAuthenticated');
 
   React.useEffect(() => {
     verify();


### PR DESCRIPTION
## Changes
- I change getting the `isAuthenticated` from `store` to `cookies` 

## Why 
- because when navigating from /instance/index and /profile/index routing is server side  which causing reload pages unlike when navigating in tabs which are client side routing 