### PR TITLE
feat(container): overriding container width when login / not login(app bar & navigation)

### DIFF
--- a/src/components/accounts/instances/InstanceContainer.js
+++ b/src/components/accounts/instances/InstanceContainer.js
@@ -6,8 +6,20 @@ import { Container } from '@mui/material';
 import { useZestyStore } from 'store';
 import { InstancesApp } from './InstancesApp';
 
-const InstanceContainer = ({ children }) => {
+const InstanceContainer = ({ children, isDashboard = false }) => {
   const { isAuthenticated } = useZestyStore((state) => state);
+
+  const renderChildren = () => {
+    if (isAuthenticated) {
+      if (isDashboard) {
+        return children;
+      } else {
+        return <InstancesApp>{children}</InstancesApp>;
+      }
+    } else {
+      return <Login />;
+    }
+  };
 
   return (
     <Main>
@@ -16,7 +28,7 @@ const InstanceContainer = ({ children }) => {
         maxWidth={false}
         sx={(theme) => ({ maxWidth: theme.breakpoints.values.xl2 })}
       >
-        {isAuthenticated ? <InstancesApp>{children}</InstancesApp> : <Login />}
+        {renderChildren()}
       </Container>
     </Main>
   );

--- a/src/components/accounts/instances/InstanceContainer.js
+++ b/src/components/accounts/instances/InstanceContainer.js
@@ -12,7 +12,10 @@ const InstanceContainer = ({ children }) => {
   return (
     <Main>
       <AppBar />
-      <Container>
+      <Container
+        maxWidth={false}
+        sx={(theme) => ({ maxWidth: theme.breakpoints.values.xl2 })}
+      >
         {isAuthenticated ? <InstancesApp>{children}</InstancesApp> : <Login />}
       </Container>
     </Main>

--- a/src/components/accounts/instances/InstanceHeader.js
+++ b/src/components/accounts/instances/InstanceHeader.js
@@ -8,18 +8,14 @@ import {
   Typography,
 } from '@mui/material';
 import React from 'react';
-import { useMediaQuery } from '@mui/material';
-import { useTheme } from '@mui/material/styles';
 import dayjs from 'dayjs';
 
 export default function InstanceHeader({ instance }) {
   const webengineUrl = `https://${instance?.randomHashID}-dev.webengine.zesty.io`;
   const managerURl = `https://${instance?.ZUID}.manager.zesty.io`;
-  const theme = useTheme();
-  const isSM = useMediaQuery(theme.breakpoints.down('md'));
 
   return (
-    <Card sx={{ maxWidth: isSM ? '100%' : 345 }}>
+    <Card sx={{ maxWidth: '100%' }}>
       {instance?.screenshotURL ? (
         <CardMedia
           component="img"

--- a/src/components/console/AppBar.js
+++ b/src/components/console/AppBar.js
@@ -13,8 +13,14 @@ import Skeleton from '@mui/material/Skeleton';
 import { useZestyStore } from 'store';
 
 export default function AppBar({ url = window.location.pathname }) {
-  const { verifySuccess, instances, userInfo, loading, setworkingInstance } =
-    useZestyStore((state) => state);
+  const {
+    verifySuccess,
+    instances,
+    userInfo,
+    loading,
+    setworkingInstance,
+    isAuthenticated,
+  } = useZestyStore((state) => state);
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   let instanceZUID = getCookie('ZESTY_WORKING_INSTANCE');
@@ -50,7 +56,14 @@ export default function AppBar({ url = window.location.pathname }) {
         marginTop: '10px',
       }}
     >
-      <Container>
+      <Container
+        maxWidth={isAuthenticated ? false : true}
+        sx={(theme) => ({
+          maxWidth: isAuthenticated
+            ? theme.breakpoints.values.xl2
+            : theme.breakpoints.values.lg,
+        })}
+      >
         <Box
           sx={{
             display: 'flex',

--- a/src/layouts/Main/Main.js
+++ b/src/layouts/Main/Main.js
@@ -10,13 +10,14 @@ import AppBar from '@mui/material/AppBar';
 
 import useScrollTrigger from '@mui/material/useScrollTrigger';
 
-import Container from 'components/Container';
+// import Container from 'components/Container';
 import TopNav from 'components/globals/TopNav';
 
 import { Topbar, Sidebar, Footer, AppNavigation } from './components';
 
 import { getCookie, setCookies } from 'cookies-next';
 import { useZestyStore } from 'store';
+import { Container } from '@mui/material';
 
 const Main = ({
   children,
@@ -112,6 +113,12 @@ const Main = ({
           zIndex={theme.zIndex.appBar}
         >
           <Container
+            maxWidth={isAuthenticated ? false : true}
+            sx={(theme) => ({
+              maxWidth: isAuthenticated
+                ? theme.breakpoints.values.xl2
+                : theme.breakpoints.values.lg,
+            })}
             paddingTop={
               hideNav || isExplorePage ? '0px !important' : '8px !important'
             }
@@ -129,10 +136,19 @@ const Main = ({
           boxShadow: hideNav ? '' : '',
           top: 0,
           backgroundColor: bgColorSwitch(),
+          py: 1,
         }}
         elevation={trigger ? 1 : 0}
       >
-        <Container paddingY={isExplorePage ? 2 : 1}>
+        <Container
+          maxWidth={isAuthenticated ? false : true}
+          sx={(theme) => ({
+            maxWidth: isAuthenticated
+              ? theme.breakpoints.values.xl2
+              : theme.breakpoints.values.lg,
+          })}
+          paddingY={isExplorePage ? 2 : 1}
+        >
           {!isUser && (
             <Topbar
               onSidebarOpen={handleSidebarOpen}

--- a/src/pages/instances/index.js
+++ b/src/pages/instances/index.js
@@ -1,30 +1,20 @@
 import React from 'react';
-import AppBar from 'components/console/AppBar';
-import { Container } from '@mui/system';
-import Main from 'layouts/Main';
 import { useZestyStore } from 'store';
-import Login from 'components/console/Login';
 import { InstancesDashboard } from 'components/accounts/instances/InstancesDashboard';
 import { useFetchWrapper } from 'components/hooks/useFetchWrapper';
-import { getCookie } from 'cookies-next';
+import InstanceContainer from 'components/accounts/instances/InstanceContainer';
 
 export default function Intances() {
   const { instances } = useFetchWrapper();
   const { setInstances } = useZestyStore((state) => state);
-
-  const isAuthenticated = getCookie('isAuthenticated');
 
   React.useEffect(() => {
     setInstances(instances);
   }, [instances]);
 
   return (
-    <Main>
-      <AppBar />
-
-      <Container>
-        {isAuthenticated ? <InstancesDashboard /> : <Login />}
-      </Container>
-    </Main>
+    <InstanceContainer isDashboard>
+      <InstancesDashboard />
+    </InstanceContainer>
   );
 }

--- a/src/theme/index.js
+++ b/src/theme/index.js
@@ -19,6 +19,16 @@ const getTheme = (mode, themeToggler) =>
         appBar: 1200,
         drawer: 1300,
       },
+      breakpoints: {
+        values: {
+          xs: 0,
+          sm: 600,
+          md: 900,
+          lg: 1200,
+          xl: 1536,
+          xl2: 2500,
+        },
+      },
       components: {
         MuiButton: {
           styleOverrides: {


### PR DESCRIPTION
Overriding container width when login / not login , by adding condition (app bar & navigation) and setting the
max-width=false and then setting the wanted width. You can see the custom breakpoints in src/theme