### PR TITLE
refactor(change forgot password message)

### DIFF
--- a/src/pages/login/forgot-password.js
+++ b/src/pages/login/forgot-password.js
@@ -35,8 +35,7 @@ const ForgotPassword = () => {
       if (response?.data || response?.meta) {
         setResponse({
           status: 'ok',
-          message: `Check your email and follow the provided link to complete the
-          reset process`,
+          message: `Your request has been submitted. If a Zesty accounts exists with this email, you will receive an email to complete your password reset.`,
         });
       } else {
         setResponse({


### PR DESCRIPTION
Note:

Scenario 1 : I tried my personal email(not zesty account) it did not receive any reset password email which is good
Scenario 2 : Tried my zesty email, it received the reset password email...

### OUTPUT : ![image](https://user-images.githubusercontent.com/44116036/187600364-db7bbb4f-6c95-4f4a-92bd-c9e781f8191c.png)

### Question:  

1. Does resetting password will always point out on this link? (https://accounts.dev.zesty.io/reset-password-confirm)
2. How can we point out the link to our website so we can create new layout for reset password page ?
3. Or we should leave it like that for now?

![image](https://user-images.githubusercontent.com/44116036/187600704-962b8ed4-048b-4be7-9f3b-07c04e98f4c3.png)
![image](https://user-images.githubusercontent.com/44116036/187600584-0baf0134-a29f-4af8-92a0-96cf5f920bbb.png)


