### PR TITLE
feat(page): reset password confirm page

### DIFF
--- a/src/components/accounts/validations/accounts.js
+++ b/src/components/accounts/validations/accounts.js
@@ -113,6 +113,22 @@ const forgotPassword = yup.object().shape({
     .required('Email is required*'),
 });
 
+const resetPassword = yup.object().shape({
+  newPassword: yup
+    .string()
+    .label('New Password')
+    .required()
+    .matches(lowercaseRegex, 'One lowercase required!')
+    .matches(uppercaseRegex, 'One uppercase required!')
+    .matches(numericRegex, 'One number required!')
+    .min(8, 'Must be atleast 8 Characters'),
+  confirmNewPassword: yup
+    .string()
+    .label('Confirm New Password')
+    .required()
+    .oneOf([yup.ref('newPassword')], 'Your passwords do not match.'),
+});
+
 export const accountsValidations = {
   email,
   password,
@@ -126,4 +142,5 @@ export const accountsValidations = {
   createWebhook,
   otpTwoFactor,
   forgotPassword,
+  resetPassword,
 };

--- a/src/pages/login/forgot-password.js
+++ b/src/pages/login/forgot-password.js
@@ -35,7 +35,7 @@ const ForgotPassword = () => {
       if (response?.data || response?.meta) {
         setResponse({
           status: 'ok',
-          message: `Your request has been submitted. If a Zesty accounts exists with this email, you will receive an email to complete your password reset.`,
+          message: `Your request has been submitted. If a Zesty account exists with this email, you will receive an email to complete your password reset.`,
         });
       } else {
         setResponse({

--- a/src/pages/login/reset-password-confirm.js
+++ b/src/pages/login/reset-password-confirm.js
@@ -1,0 +1,171 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Container,
+  InputAdornment,
+  Paper,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import { accountsValidations, FormInput } from 'components/accounts';
+import PasswordIcon from '@mui/icons-material/Password';
+import EditOffIcon from '@mui/icons-material/EditOff';
+import DoNotDisturbIcon from '@mui/icons-material/DoNotDisturb';
+import { LoadingButton } from '@mui/lab';
+import { useFormik } from 'formik';
+import { useState } from 'react';
+import { useZestyStore } from 'store';
+
+const ResetPasswordConfirm = ({ address, token }) => {
+  document.title = 'Reset Password Confirmation';
+  const { ZestyAPI } = useZestyStore((state) => state);
+  const [loading, setLoading] = useState(false);
+  const [response, setResponse] = useState({});
+  const formik = useFormik({
+    validationSchema: accountsValidations.resetPassword,
+    initialValues: {
+      newPassword: '',
+      confirmNewPassword: '',
+    },
+    onSubmit: async (values) => {
+      setLoading(true);
+      const response = await ZestyAPI.userResetPasswordConfirm(
+        address,
+        values.newPassword,
+        token,
+      );
+
+      if (response?.data || response?.meta) {
+        setResponse({
+          status: 'ok',
+          message: response.message,
+        });
+      } else {
+        setResponse({
+          status: 'bad',
+          message: response.message,
+        });
+      }
+      formik.resetForm();
+      setLoading(false);
+    },
+  });
+
+  const theme = useTheme();
+  return (
+    <Container
+      maxWidth={false}
+      disableGutters
+      sx={(theme) => ({
+        maxWidth: theme.breakpoints.values.xl2,
+        height: '100vh',
+      })}
+    >
+      <Box
+        display="grid"
+        justifyContent="center"
+        alignItems="center"
+        height="100%"
+        px={5}
+      >
+        <Stack alignItems="center">
+          <img
+            src={
+              theme.palette.mode === 'light'
+                ? 'https://brand.zesty.io/zesty-io-logo-vertical.svg'
+                : 'https://brand.zesty.io/zesty-io-logo-vertical-light-color.svg'
+            }
+            alt="logo"
+            height="150px"
+            width="150px"
+          />
+          <Paper elevation={5} sx={{ mt: 5 }}>
+            <Stack spacing={2} p={5} maxWidth="660px">
+              <Typography color="text.secondary">
+                Minimum 8 characters. At least one number. A combination of
+                lower and uppercase letters.
+              </Typography>
+              <form noValidate onSubmit={formik.handleSubmit}>
+                <FormInput
+                  color="secondary"
+                  name="newPassword"
+                  customLabel="New Password"
+                  formik={formik}
+                  placeholder="Enter your new password"
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <PasswordIcon />
+                      </InputAdornment>
+                    ),
+                  }}
+                />
+                <FormInput
+                  color="secondary"
+                  name="confirmNewPassword"
+                  customLabel="Confirm New Password"
+                  formik={formik}
+                  placeholder="Repeat your new password"
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <PasswordIcon />
+                      </InputAdornment>
+                    ),
+                  }}
+                />
+                {response?.status && (
+                  <Alert
+                    onClose={() => setResponse({})}
+                    color={response?.status === 'ok' ? 'success' : 'error'}
+                    severity={response?.status === 'ok' ? 'success' : 'error'}
+                    sx={{ mb: 2 }}
+                  >
+                    {response?.message}
+                  </Alert>
+                )}
+
+                <Stack spacing={2} direction="row" alignItems="center">
+                  <LoadingButton
+                    type="submit"
+                    startIcon={<EditOffIcon />}
+                    variant="contained"
+                    color="secondary"
+                    size="small"
+                    loading={loading}
+                    fullWidth
+                  >
+                    RESET PASSWORD
+                  </LoadingButton>
+                  <Button
+                    startIcon={<DoNotDisturbIcon />}
+                    href="/login"
+                    color="secondary"
+                    variant="outlined"
+                  >
+                    Cancel
+                  </Button>
+                </Stack>
+              </form>
+            </Stack>
+          </Paper>
+        </Stack>
+      </Box>
+    </Container>
+  );
+};
+
+export default ResetPasswordConfirm;
+
+export async function getServerSideProps(context) {
+  const { address, token } = context.query;
+
+  return {
+    props: {
+      address,
+      token,
+    },
+  };
+}

--- a/src/pages/login/reset-password-confirm.js
+++ b/src/pages/login/reset-password-confirm.js
@@ -3,14 +3,12 @@ import {
   Box,
   Button,
   Container,
-  InputAdornment,
   Paper,
   Stack,
   Typography,
 } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { accountsValidations, FormInput } from 'components/accounts';
-import PasswordIcon from '@mui/icons-material/Password';
 import EditOffIcon from '@mui/icons-material/EditOff';
 import DoNotDisturbIcon from '@mui/icons-material/DoNotDisturb';
 import { LoadingButton } from '@mui/lab';
@@ -94,13 +92,7 @@ const ResetPasswordConfirm = ({ address, token }) => {
                   customLabel="New Password"
                   formik={formik}
                   placeholder="Enter your new password"
-                  InputProps={{
-                    startAdornment: (
-                      <InputAdornment position="start">
-                        <PasswordIcon />
-                      </InputAdornment>
-                    ),
-                  }}
+                  type="password"
                 />
                 <FormInput
                   color="secondary"
@@ -108,13 +100,7 @@ const ResetPasswordConfirm = ({ address, token }) => {
                   customLabel="Confirm New Password"
                   formik={formik}
                   placeholder="Repeat your new password"
-                  InputProps={{
-                    startAdornment: (
-                      <InputAdornment position="start">
-                        <PasswordIcon />
-                      </InputAdornment>
-                    ),
-                  }}
+                  type="password"
                 />
                 {response?.status && (
                   <Alert


### PR DESCRIPTION
Sample URL : http://test.zesty.io:3000/login/reset-password-confirm/?address=gian.espinosa%40zesty.io&token=0qjrb1nqvqvml79tcr9hq0l430213l0vzzh6d5m3
reset password confirm page

![image](https://user-images.githubusercontent.com/44116036/187872253-e71c8da2-a999-4337-9269-587e757d7bdd.png)

Cors Error:
PR in fetchwrapper: https://github.com/zesty-io/fetch-wrapper/pull/37

I believe once this CORS issue is solve in backend the pr above will work...

![image](https://user-images.githubusercontent.com/44116036/187872854-69a901cd-63ee-4cc6-b24c-d195142d5a79.png)
