### PR TITLE
feat(instance card virtualization): instance card virtualization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "react-lazy-load-image-component": "^1.5.4",
         "react-player": "^2.10.0",
         "react-slick": "^0.28.1",
+        "react-virtualized": "^9.22.3",
         "react-visibility-sensor": "^5.1.1",
         "react-window": "^1.8.7",
         "shortid": "^2.2.16",
@@ -14984,6 +14985,23 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/react-virtualized": {
+      "version": "9.22.3",
+      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz",
+      "integrity": "sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "clsx": "^1.0.4",
+        "dom-helpers": "^5.1.3",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha"
+      }
+    },
     "node_modules/react-visibility-sensor": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/react-visibility-sensor/-/react-visibility-sensor-5.1.1.tgz",
@@ -28540,6 +28558,19 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-virtualized": {
+      "version": "9.22.3",
+      "resolved": "https://registry.npmjs.org/react-virtualized/-/react-virtualized-9.22.3.tgz",
+      "integrity": "sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "clsx": "^1.0.4",
+        "dom-helpers": "^5.1.3",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "react-visibility-sensor": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "react-lazy-load-image-component": "^1.5.4",
     "react-player": "^2.10.0",
     "react-slick": "^0.28.1",
+    "react-virtualized": "^9.22.3",
     "react-visibility-sensor": "^5.1.1",
     "react-window": "^1.8.7",
     "shortid": "^2.2.16",

--- a/package.json
+++ b/package.json
@@ -135,5 +135,11 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "overrides": {
+    "react-virtualized": {
+      "react": "17.0.2",
+      "react-dom": "17.0.2"
+    }
   }
 }

--- a/src/components/accounts/instances/InstancesTypes.js
+++ b/src/components/accounts/instances/InstancesTypes.js
@@ -1,6 +1,16 @@
-import { Grid, List, Stack, Typography } from '@mui/material';
+import { Grid, Stack, Typography } from '@mui/material';
 import React from 'react';
 import ZInstanceItem from '../dashboard/ui/ZInstanceItem';
+import { useTheme } from '@mui/material/styles';
+import { useMediaQuery } from '@mui/material';
+
+import {
+  WindowScroller,
+  AutoSizer,
+  List as RVList,
+  CellMeasurerCache,
+  CellMeasurer,
+} from 'react-virtualized';
 
 const InstancesTypes = ({
   view,
@@ -10,6 +20,19 @@ const InstancesTypes = ({
   isLoading,
   renderInstances,
 }) => {
+  const theme = useTheme();
+  const isXS = useMediaQuery(theme.breakpoints.up('xs'));
+  const isSM = useMediaQuery(theme.breakpoints.up('sm'));
+  const isMD = useMediaQuery(theme.breakpoints.up('md'));
+  const isLG = useMediaQuery(theme.breakpoints.up('lg'));
+  const isXL2 = useMediaQuery(theme.breakpoints.up('xl2'));
+  const cache = new CellMeasurerCache({
+    defaultHeight: 73,
+    fixedWidth: true,
+  });
+
+  const CARD_WIDTH = 340;
+
   if (isLoading) {
     return (
       <Grid container spacing={2}>
@@ -38,27 +61,127 @@ const InstancesTypes = ({
         </Typography>
 
         {view === 'list' ? (
-          <List>
-            {lists?.map((instance) => {
-              return renderInstances('list', instance);
-            })}
-          </List>
-        ) : (
-          <Grid container spacing={2}>
-            {isLoading
-              ? [...new Array(12)].map((i) => (
-                  <Grid key={i} item xs={12} sm={6} md={4} lg={3} xl2={2}>
-                    <ZInstanceItem isLoading={isLoading} />
-                  </Grid>
-                ))
-              : lists?.map((instance, index) => {
+          <WindowScroller>
+            {({ height, scrollTop }) => (
+              <AutoSizer disableHeight>
+                {({ width }) => {
                   return (
-                    <Grid key={index} item xs={12} sm={6} md={4} lg={3} xl2={2}>
-                      {renderInstances('grid', instance)}
-                    </Grid>
+                    <RVList
+                      deferredMeasurementCache={cache}
+                      autoHeight
+                      height={height}
+                      width={width}
+                      scrollTop={scrollTop}
+                      rowHeight={80}
+                      rowCount={lists?.length}
+                      overscanRowCount={10}
+                      rowRenderer={({ index, key, style, parent }) => {
+                        const instance = lists[index];
+                        return (
+                          // They get rendered into the Row
+                          <CellMeasurer
+                            cache={cache}
+                            columnIndex={0}
+                            key={key}
+                            parent={parent}
+                            rowIndex={index}
+                          >
+                            <div key={key} style={style}>
+                              {renderInstances('list', instance)}
+                            </div>
+                          </CellMeasurer>
+                        );
+                      }}
+                    />
                   );
-                })}
-          </Grid>
+                }}
+              </AutoSizer>
+            )}
+          </WindowScroller>
+        ) : (
+          <WindowScroller>
+            {({ height, scrollTop }) => (
+              <AutoSizer disableHeight>
+                {({ width }) => {
+                  const itemsPerRow = isXL2
+                    ? 6
+                    : isLG
+                    ? 4
+                    : isMD
+                    ? 3
+                    : isSM
+                    ? 2
+                    : isXS
+                    ? 1
+                    : 1;
+                  // The || 1 part is a simple hack that makes it work in a really small viewport (if someone totally collapses the window)
+                  const rowCount = Math.ceil(lists.length / itemsPerRow); // List will need the number of rows in order to be able to properly know what to render and what not to
+                  return (
+                    <RVList
+                      // deferredMeasurementCache={cache}
+                      autoHeight
+                      height={height}
+                      width={width}
+                      scrollTop={scrollTop}
+                      rowHeight={CARD_WIDTH}
+                      rowCount={rowCount}
+                      rowRenderer={({ index, key, style, parent }) => {
+                        // This is where stuff gets interesting/confusing
+                        // We are going to constantly update an array of items that our rowRenderer will render
+                        const items = [];
+                        // This array will have a start and an end.
+                        // The start is the top of the window
+                        // The end is the bottom of the window
+                        // the for loop below will constantly be updated as the the user scrolls down
+                        const fromIndex = index * itemsPerRow;
+
+                        const toIndex = Math.min(
+                          fromIndex + itemsPerRow,
+                          lists.length,
+                        );
+
+                        for (let i = fromIndex; i < toIndex; i++) {
+                          const instance = lists[i];
+
+                          items.push(
+                            <Grid
+                              key={i}
+                              item
+                              xs={12}
+                              sm={6}
+                              md={4}
+                              lg={3}
+                              xl2={2}
+                            >
+                              {renderInstances('grid', instance)}
+                            </Grid>,
+                          );
+                        }
+
+                        return (
+                          // They get rendered into the Row
+                          <CellMeasurer
+                            cache={cache}
+                            columnIndex={0}
+                            key={key}
+                            parent={parent}
+                            rowIndex={index}
+                          >
+                            {/* need this div to prevent conflict with the spacing of container grid */}
+                            <div key={key} style={style}>
+                              <Grid container spacing={2}>
+                                {items}
+                              </Grid>
+                            </div>
+                          </CellMeasurer>
+                        );
+                      }}
+                    />
+                  );
+                }}
+              </AutoSizer>
+            )}
+          </WindowScroller>
         )}
       </Stack>
     )

--- a/src/components/accounts/instances/InstancesTypes.js
+++ b/src/components/accounts/instances/InstancesTypes.js
@@ -62,37 +62,42 @@ const InstancesTypes = ({
 
         {view === 'list' ? (
           <WindowScroller>
-            {({ height, scrollTop }) => (
+            {/* adding registerChild to the outer div will help on the multiple lists to prevent this issue
+                https://github.com/bvaughn/react-virtualized/issues/1324
+            */}
+            {({ height, scrollTop, registerChild }) => (
               <AutoSizer disableHeight>
                 {({ width }) => {
                   return (
-                    <RVList
-                      deferredMeasurementCache={cache}
-                      autoHeight
-                      height={height}
-                      width={width}
-                      scrollTop={scrollTop}
-                      rowHeight={80}
-                      rowCount={lists?.length}
-                      overscanRowCount={10}
-                      rowRenderer={({ index, key, style, parent }) => {
-                        const instance = lists[index];
-                        return (
-                          // They get rendered into the Row
-                          <CellMeasurer
-                            cache={cache}
-                            columnIndex={0}
-                            key={key}
-                            parent={parent}
-                            rowIndex={index}
-                          >
-                            <div key={key} style={style}>
-                              {renderInstances('list', instance)}
-                            </div>
-                          </CellMeasurer>
-                        );
-                      }}
-                    />
+                    <div ref={(el) => registerChild(el)}>
+                      <RVList
+                        deferredMeasurementCache={cache}
+                        autoHeight
+                        height={height}
+                        width={width}
+                        scrollTop={scrollTop}
+                        rowHeight={80}
+                        rowCount={lists?.length}
+                        overscanRowCount={10}
+                        rowRenderer={({ index, key, style, parent }) => {
+                          const instance = lists[index];
+                          return (
+                            // They get rendered into the Row
+                            <CellMeasurer
+                              cache={cache}
+                              columnIndex={0}
+                              key={key}
+                              parent={parent}
+                              rowIndex={index}
+                            >
+                              <div key={key} style={style}>
+                                {renderInstances('list', instance)}
+                              </div>
+                            </CellMeasurer>
+                          );
+                        }}
+                      />
+                    </div>
                   );
                 }}
               </AutoSizer>
@@ -100,7 +105,10 @@ const InstancesTypes = ({
           </WindowScroller>
         ) : (
           <WindowScroller>
-            {({ height, scrollTop }) => (
+            {/* adding registerChild to the outer div will help on the multiple lists to prevent this issue
+                https://github.com/bvaughn/react-virtualized/issues/1324
+            */}
+            {({ height, scrollTop, registerChild }) => (
               <AutoSizer disableHeight>
                 {({ width }) => {
                   const itemsPerRow = isXL2
@@ -117,66 +125,68 @@ const InstancesTypes = ({
                   // The || 1 part is a simple hack that makes it work in a really small viewport (if someone totally collapses the window)
                   const rowCount = Math.ceil(lists.length / itemsPerRow); // List will need the number of rows in order to be able to properly know what to render and what not to
                   return (
-                    <RVList
-                      // deferredMeasurementCache={cache}
-                      autoHeight
-                      height={height}
-                      width={width}
-                      scrollTop={scrollTop}
-                      rowHeight={CARD_WIDTH}
-                      rowCount={rowCount}
-                      rowRenderer={({ index, key, style, parent }) => {
-                        // This is where stuff gets interesting/confusing
-                        // We are going to constantly update an array of items that our rowRenderer will render
-                        const items = [];
-                        // This array will have a start and an end.
-                        // The start is the top of the window
-                        // The end is the bottom of the window
-                        // the for loop below will constantly be updated as the the user scrolls down
-                        const fromIndex = index * itemsPerRow;
+                    <div ref={(el) => registerChild(el)}>
+                      <RVList
+                        deferredMeasurementCache={cache}
+                        autoHeight
+                        height={height}
+                        width={width}
+                        scrollTop={scrollTop}
+                        rowHeight={CARD_WIDTH}
+                        rowCount={rowCount}
+                        rowRenderer={({ index, key, style, parent }) => {
+                          // This is where stuff gets interesting/confusing
+                          // We are going to constantly update an array of items that our rowRenderer will render
+                          const items = [];
+                          // This array will have a start and an end.
+                          // The start is the top of the window
+                          // The end is the bottom of the window
+                          // the for loop below will constantly be updated as the the user scrolls down
+                          const fromIndex = index * itemsPerRow;
 
-                        const toIndex = Math.min(
-                          fromIndex + itemsPerRow,
-                          lists.length,
-                        );
-
-                        for (let i = fromIndex; i < toIndex; i++) {
-                          const instance = lists[i];
-
-                          items.push(
-                            <Grid
-                              key={i}
-                              item
-                              xs={12}
-                              sm={6}
-                              md={4}
-                              lg={3}
-                              xl2={2}
-                            >
-                              {renderInstances('grid', instance)}
-                            </Grid>,
+                          const toIndex = Math.min(
+                            fromIndex + itemsPerRow,
+                            lists.length,
                           );
-                        }
 
-                        return (
-                          // They get rendered into the Row
-                          <CellMeasurer
-                            cache={cache}
-                            columnIndex={0}
-                            key={key}
-                            parent={parent}
-                            rowIndex={index}
-                          >
-                            {/* need this div to prevent conflict with the spacing of container grid */}
-                            <div key={key} style={style}>
-                              <Grid container spacing={2}>
-                                {items}
-                              </Grid>
-                            </div>
-                          </CellMeasurer>
-                        );
-                      }}
-                    />
+                          for (let i = fromIndex; i < toIndex; i++) {
+                            const instance = lists[i];
+
+                            items.push(
+                              <Grid
+                                key={i}
+                                item
+                                xs={12}
+                                sm={6}
+                                md={4}
+                                lg={3}
+                                xl2={2}
+                              >
+                                {renderInstances('grid', instance)}
+                              </Grid>,
+                            );
+                          }
+
+                          return (
+                            // They get rendered into the Row
+                            <CellMeasurer
+                              cache={cache}
+                              columnIndex={0}
+                              key={key}
+                              parent={parent}
+                              rowIndex={index}
+                            >
+                              {/* need this div to prevent conflict with the spacing of container grid */}
+                              <div key={key} style={style}>
+                                <Grid container spacing={2}>
+                                  {items}
+                                </Grid>
+                              </div>
+                            </CellMeasurer>
+                          );
+                        }}
+                      />
+                    </div>
                   );
                 }}
               </AutoSizer>


### PR DESCRIPTION
this virtualization works, but it has bugs because i reused the InstancesTypes component that has virtualization inside,

### Try this scenario when you have a lot of items cards

scenario: when the **Favorites**, first row remove in the dom , the one in **Instances** also gets remove in the first row or sometimes not visible because they are sharing the same component or parent .... 

To solve this, a way to separate their concern with each other so the other category does not have same behaviour with each other


UPDATE:  Solved this bug with this reference : https://github.com/bvaughn/react-virtualized/issues/1324
