### PR TITLE
Feat: Accounts Head 

### DIFF
--- a/src/components/accounts/instances/InstancesApp.js
+++ b/src/components/accounts/instances/InstancesApp.js
@@ -19,6 +19,7 @@ import { instanceTabs } from 'components/accounts/instances/tabs';
 import { lang } from 'components/accounts/instances/lang';
 import { useMediaQuery } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
+import { ZestyAccountsHead } from 'components/globals/ZestyAccountsHead';
 
 let capitalize = (s) => (s = s.charAt(0).toUpperCase() + s.slice(1));
 
@@ -69,13 +70,11 @@ const Index = ({ children }) => {
     }
   }, [router.isReady]);
 
-  React.useEffect(() => {
-    document.title =
-      instance.name + ` Instance - ${currentPage} - Zesty.io Console`;
-  }, [instance, currentPage]);
+  const title = instance.name + ` Instance - ${currentPage} - Zesty.io Console`;
 
   return (
     <Box>
+      <ZestyAccountsHead title={title} />
       {isLG ? (
         <Box sx={{ display: 'grid', gridTemplateColumns: '240px 1fr' }}>
           <Box

--- a/src/components/accounts/profile/ProfileContainer.js
+++ b/src/components/accounts/profile/ProfileContainer.js
@@ -2,14 +2,19 @@ import Main from 'layouts/Main/Main';
 import React from 'react';
 import { Container } from '@mui/material';
 import { ProfileApp } from './ProfileApp';
+import { ZestyAccountsHead } from 'components/globals/ZestyAccountsHead';
+import { capitalizeFirstLetter } from 'utils';
 
 const Index = ({ children }) => {
+  const path =
+    window.location.pathname.split('/')?.filter((e) => e)[1] || 'Profile';
   const renderChildren = () => {
     return <ProfileApp>{children}</ProfileApp>;
   };
 
   return (
     <Main>
+      <ZestyAccountsHead title={`Accounts: ${capitalizeFirstLetter(path)}`} />
       <Container
         maxWidth={false}
         disableGutters

--- a/src/components/globals/ZestyAccountsHead.js
+++ b/src/components/globals/ZestyAccountsHead.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import Head from 'next/head';
+
+export const ZestyAccountsHead = ({
+  title = 'Accounts',
+  description = 'Accounts',
+  ogimage = 'https://kfg6bckb.media.zestyio.com/zesty-share-image-generic.png?width=1200',
+}) => {
+  return (
+    <Head>
+      <title>{title}</title>
+      <link
+        rel="icon"
+        href="https://brand.zesty.io/favicon.png"
+        type="image/png"
+      />
+      <meta
+        name="viewport"
+        content="width=device-width, initial-scale=1, shrink-to-fit=no"
+      />
+      <meta property="og:title" content={title} />
+      <meta name="description" value={description} />
+      <meta property="og:description" content={description} />
+      <meta property="og:image" content={ogimage} />
+
+      <link
+        href="https://fonts.googleapis.com/icon?family=Material+Icons"
+        rel="stylesheet"
+      />
+      <link
+        rel="stylesheet"
+        href="https://fonts.googleapis.com/css?family=Mulish"
+      />
+    </Head>
+  );
+};

--- a/src/pages/instances/index.js
+++ b/src/pages/instances/index.js
@@ -2,11 +2,11 @@ import React from 'react';
 import { useZestyStore } from 'store';
 import InstancesDashboardV2 from 'components/accounts/instances/InstanceDashboardV2';
 import { useFetchWrapper } from 'components/hooks/useFetchWrapper';
+import { ZestyAccountsHead } from 'components/globals/ZestyAccountsHead';
 
 export { default as getServerSideProps } from 'lib/protectedRouteGetServerSideProps';
 
 export default function Instances() {
-  document.title = 'Accounts: Instances';
   const { instances } = useFetchWrapper();
   const { setInstances } = useZestyStore((state) => state);
 
@@ -14,7 +14,12 @@ export default function Instances() {
     setInstances(instances);
   }, [instances]);
 
-  return <InstancesDashboardV2 />;
+  return (
+    <>
+      <ZestyAccountsHead title={'Accounts: Instances'} />
+      <InstancesDashboardV2 />;
+    </>
+  );
 }
 
 Instances.data = {

--- a/src/pages/teams/index.js
+++ b/src/pages/teams/index.js
@@ -6,11 +6,11 @@ import AddTeam from 'components/accounts/teams/AddTeam';
 import ManageTeam from 'components/accounts/teams/ManageTeam';
 import { useZestyStore } from 'store';
 import TeamInvites from 'components/accounts/teams/TeamInvites';
+import { ZestyAccountsHead } from 'components/globals/ZestyAccountsHead';
 
 export { default as getServerSideProps } from 'lib/protectedRouteGetServerSideProps';
 
 const Teams = () => {
-  document.title = 'Accounts: Teams';
   const {
     ZestyAPI,
     verifySuccess: { userZuid },
@@ -39,6 +39,7 @@ const Teams = () => {
 
   return (
     <TeamsContainer>
+      <ZestyAccountsHead title={'Accounts: Teams'} />
       <Box p={3}>
         <Typography
           display="flex"

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -319,3 +319,7 @@ export const gravatarImg = (userInfo = {}) => {
   const res = 'https://www.gravatar.com/avatar/' + hashMD5(userInfo?.email);
   return res;
 };
+
+export const capitalizeFirstLetter = (string) => {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+};


### PR DESCRIPTION
## Changes
- Added ZestyAccountsHead component for showing `title` and `favicon` in accounts pages  

https://user-images.githubusercontent.com/71545960/196903520-9021d7b3-796f-45de-9216-e0d2f3b4d720.mp4


