### PR TITLE
fix(fix non https redirect)

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,11 +1,13 @@
 import { NextResponse } from 'next/server';
 
-export async function middleware(request, ev) {
+export async function middleware(request) {
   // https redirect
+
   if (
-    process.env.PRODUCTION === 'true' &&
+    JSON.parse(process.env.PRODUCTION) &&
     !request.nextUrl.origin.includes('localhost') &&
-    request.headers.get('x-forwarded-proto') !== 'https'
+    (request.headers.get('x-forwarded-proto') !== 'https' ||
+      request.headers.get('referer')?.split(':')[0] !== 'https')
   ) {
     return NextResponse.redirect(
       `https://${request.headers.get('host')}${request.nextUrl.pathname}`,


### PR DESCRIPTION
- parsing the env production to make sure it is type of boolean not a string
- getting referer header to get the protocol also instead of depending on the x-forwarded-proto cause i cant test it in local dev because it's throwing undefined or null