### PR TITLE
Getserversideprops optimization

### DIFF
--- a/src/pages/docs/[...slug].js
+++ b/src/pages/docs/[...slug].js
@@ -3,6 +3,7 @@ import { Docs } from 'views/Docs';
 import { useRouter } from 'next/router';
 import { transFormMainData } from 'views/Docs/helper';
 import { useZestyStore } from 'store';
+import { ZestyAccountsHead } from 'components/globals/ZestyAccountsHead';
 
 export { default as getServerSideProps } from 'lib/accounts/protectedRouteGetServerSideProps';
 
@@ -111,5 +112,10 @@ export default function DocsPage(props) {
     }
   }, []);
 
-  return <Docs {...docsProps} />;
+  return (
+    <>
+      <ZestyAccountsHead title={'Zesty.io - Documentation'} />
+      <Docs {...docsProps} />;
+    </>
+  );
 }

--- a/src/pages/docs/index.js
+++ b/src/pages/docs/index.js
@@ -14,6 +14,7 @@ import {
 } from '@mui/material';
 import { SearchModal } from 'views/Docs/SearchModal';
 import { AlgoSearch } from 'views/Docs/AlgoSearch';
+import { ZestyAccountsHead } from 'components/globals/ZestyAccountsHead';
 
 export { default as getServerSideProps } from 'lib/accounts/protectedRouteGetServerSideProps';
 
@@ -32,6 +33,7 @@ const DocsPage = (props) => {
 
   return (
     <>
+      <ZestyAccountsHead title={'Zesty.io - Documentation'} />
       <MainWrapper docsLanding customRouting={[]}>
         <Box
           sx={{

--- a/src/pages/docs/parsley/api-reference/index.js
+++ b/src/pages/docs/parsley/api-reference/index.js
@@ -8,6 +8,7 @@ import { DocsSidebar } from 'components/docs/DocsSidebar';
 import { useZestyStore } from 'store';
 import { fetchMarkdownFile, parseMarkdownFile } from 'utils/docs';
 import { PARSLEY } from 'utils/docs/constants';
+import { ZestyAccountsHead } from 'components/globals/ZestyAccountsHead';
 
 const muiContentOverrides = {
   h1: {
@@ -77,6 +78,7 @@ const ApiReferencePage = (props) => {
   }, []);
   return (
     <MainWrapper>
+      <ZestyAccountsHead title={'Zesty.io - Documentation'} />
       <Stack direction={'row'}>
         {/* SIDEBAR */}
         <DocsSidebar

--- a/src/pages/docs/parsley/guides/[...slug].js
+++ b/src/pages/docs/parsley/guides/[...slug].js
@@ -9,6 +9,7 @@ import { useZestyStore } from 'store';
 import { fetchMarkdownFile, parseMarkdownFile } from 'utils/docs';
 import { PARSLEY, PARSLEY_GUIDES } from 'utils/docs/constants';
 import { useRouter } from 'next/router';
+import { ZestyAccountsHead } from 'components/globals/ZestyAccountsHead';
 
 const muiContentOverrides = {
   h1: {
@@ -89,6 +90,7 @@ const ApiReferencePage = (props) => {
   }, []);
   return (
     <MainWrapper>
+      <ZestyAccountsHead title={'Zesty.io - Documentation'} />
       <Stack direction={'row'}>
         {/* SIDEBAR */}
         <DocsSidebar

--- a/src/pages/docs/parsley/guides/index.js
+++ b/src/pages/docs/parsley/guides/index.js
@@ -7,6 +7,7 @@ import { DocsSidebar } from 'components/docs/DocsSidebar';
 import { useZestyStore } from 'store';
 import axios from 'axios';
 import { PARSLEY_GUIDES } from 'utils/docs/constants';
+import { ZestyAccountsHead } from 'components/globals/ZestyAccountsHead';
 
 const GuidePage = (props) => {
   const { setalgoliaApiKey, setalgoliaAppId, setalgoliaIndex } = useZestyStore(
@@ -58,6 +59,8 @@ const GuidePage = (props) => {
   }, []);
   return (
     <MainWrapper>
+      <ZestyAccountsHead title={'Zesty.io - Documentation'} />
+
       <Stack direction={'row'}>
         {/* SIDEBARR */}
         <DocsSidebar

--- a/src/pages/docs/parsley/index.js
+++ b/src/pages/docs/parsley/index.js
@@ -8,6 +8,7 @@ import { DocsSidebar } from 'components/docs/DocsSidebar';
 import { useZestyStore } from 'store';
 import { fetchMarkdownFile, parseMarkdownFile } from 'utils/docs';
 import { PARSLEY } from 'utils/docs/constants';
+import { ZestyAccountsHead } from 'components/globals/ZestyAccountsHead';
 
 const muiContentOverrides = {
   h1: {
@@ -78,6 +79,8 @@ const ParsleyOverviewPage = (props) => {
 
   return (
     <MainWrapper>
+      <ZestyAccountsHead title={'Zesty.io - Documentation'} />
+
       <Stack direction={'row'}>
         {/* SIDEBARR */}
         <DocsSidebar

--- a/src/pages/docs/parsley/tour/[...slug].js
+++ b/src/pages/docs/parsley/tour/[...slug].js
@@ -20,6 +20,7 @@ import { githubDarkInit } from '@uiw/codemirror-theme-github';
 import { useZestyStore } from 'store';
 import { grey } from '@mui/material/colors';
 import { PARSLEY_EXAMPLE_DATA } from 'utils/docs';
+import { ZestyAccountsHead } from 'components/globals/ZestyAccountsHead';
 export { default as getServerSideProps } from 'lib/accounts/protectedRouteGetServerSideProps';
 const leftTabs = [
   { label: 'Code Example', value: 'code example' },
@@ -577,6 +578,8 @@ const Slug = (props) => {
 
   return (
     <MainWrapper>
+      <ZestyAccountsHead title={'Zesty.io - Documentation'} />
+
       <Stack direction="row">
         {/* SIDEBAR */}
         <DocsSidebar

--- a/src/pages/docs/parsley/tour/index.js
+++ b/src/pages/docs/parsley/tour/index.js
@@ -7,6 +7,7 @@ import { DocsSidebar } from 'components/docs/DocsSidebar';
 import { useZestyStore } from 'store';
 import axios from 'axios';
 import { useRouter } from 'next/router';
+import { ZestyAccountsHead } from 'components/globals/ZestyAccountsHead';
 
 const TourPage = (props) => {
   const router = useRouter();
@@ -63,6 +64,8 @@ const TourPage = (props) => {
   }, []);
   return (
     <MainWrapper>
+      <ZestyAccountsHead title={'Zesty.io - Documentation'} />
+
       <Stack direction={'row'}>
         {/* SIDEBARR */}
         <DocsSidebar


### PR DESCRIPTION
Optimize `protectedRouteGetServerSideProps.js` 
- use parallel fetching of api #1708 
- update parsely tour endpoints 
- added zesty head in `docs` pages 