### PR TITLE
fix(tabs render on preload) to prevent showing slow loading of image

### DIFF
--- a/src/revamp/ui/TabsSection/index.js
+++ b/src/revamp/ui/TabsSection/index.js
@@ -4,7 +4,7 @@ import ImageRoundedIcon from '@mui/icons-material/ImageRounded';
 import TranslateRoundedIcon from '@mui/icons-material/TranslateRounded';
 // import ApiRoundedIcon from '@mui/icons-material/ApiRounded';
 import ScienceRoundedIcon from '@mui/icons-material/ScienceRounded';
-import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { TabContext, TabList } from '@mui/lab';
 // import { Database, Brain } from '@zesty-io/material/';
 import PsychologyRoundedIcon from '@mui/icons-material/PsychologyRounded';
 import SchemaRoundedIcon from '@mui/icons-material/SchemaRounded';
@@ -108,6 +108,20 @@ const tabLists = [
   },
 ];
 
+function TabPanel(props) {
+  const { children, value, index, ...other } = props;
+  return (
+    <Typography
+      component="div"
+      role="tabpanel"
+      hidden={value !== index}
+      {...other}
+    >
+      {children}
+    </Typography>
+  );
+}
+
 const TabsSection = ({
   header = 'Enterprise grade features  available for everyone out-of-the-box',
 }) => {
@@ -174,7 +188,7 @@ const TabsSection = ({
         >
           {tabLists.map((tab) => (
             <Tab
-              key={tab}
+              key={tab.name}
               label={tab.name}
               value={tab.name}
               iconPosition="start"
@@ -187,7 +201,12 @@ const TabsSection = ({
           ))}
         </TabList>
         {tabLists.map((tab) => (
-          <TabPanel key={tab.name} sx={{ p: 0, pt: 3 }} value={tab.name}>
+          <TabPanel
+            key={tab.name}
+            sx={{ p: 0, pt: 3 }}
+            value={value}
+            index={tab.name}
+          >
             {tab.component}
           </TabPanel>
         ))}


### PR DESCRIPTION
**_Solution_**: I made the tabs here preload, so whenever you select a tab all those images are ready. 

**_Cause of issue:_** The MUI Tabs don't render all tabs at once it just renders what is selected by default then that's the time only the images will be fetch in the network and then cached

[screencast-test.zesty.io_3000-2023.06.22-21_43_30.webm](https://github.com/zesty-io/website/assets/44116036/bd0f42c5-77c8-4fad-8241-db1a44e99326)
