### PR TITLE
fix(zestymrkdownparser): add parse for bold and italic (#1878)

### DIFF
--- a/src/components/markdown-styling/ZestyMarkdownParser.js
+++ b/src/components/markdown-styling/ZestyMarkdownParser.js
@@ -8,7 +8,9 @@ import {
   MDH2,
   MDH3,
   MDImage,
+  MDItalic,
   MDParagraph,
+  MDStrong,
 } from './components';
 
 // Main //
@@ -31,6 +33,8 @@ export const ZestyMarkdownParser = ({
     h2: MDH2,
     h3: MDH3,
     pre: MDCodeBlock,
+    strong: MDStrong,
+    em: MDItalic,
   };
   return (
     <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>

--- a/src/components/markdown-styling/components/MDCodeBlock.js
+++ b/src/components/markdown-styling/components/MDCodeBlock.js
@@ -18,7 +18,6 @@ export const MDCodeBlock = ({ node }) => {
         editable={false}
         value={codeTxt}
         placeholder={'Click Run to view the response'}
-        // height={'300px'}
         extensions={[javascript({ jsx: true }), EditorView.lineWrapping]}
         onChange={() => {}}
         style={{ fontSize: '18px', width: '100%' }}

--- a/src/components/markdown-styling/components/MDItalic.js
+++ b/src/components/markdown-styling/components/MDItalic.js
@@ -1,0 +1,12 @@
+import { Stack, Typography } from '@mui/material';
+
+export const MDItalic = ({ node }) => {
+  const str = node?.children[0].children[0]?.value || '';
+  return (
+    <Stack data-testid="MDItalic-component">
+      <Typography fontWeight={'400'} fontStyle={'italic'}>
+        {str}
+      </Typography>
+    </Stack>
+  );
+};

--- a/src/components/markdown-styling/components/MDParagraph.js
+++ b/src/components/markdown-styling/components/MDParagraph.js
@@ -2,6 +2,8 @@ import { Typography, Link, Box, Stack } from '@mui/material';
 import FileOpenIcon from '@mui/icons-material/FileOpen';
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos';
 import { MDImage } from './MDImage';
+import { MDStrong } from './MDStrong';
+import { MDItalic } from './MDItalic';
 
 const LinkComponent = ({ node }) => {
   return (
@@ -71,6 +73,12 @@ export const MDParagraph = ({
     }
   });
 
+  if (node.children.length === 1 && node.children[0].tagName === 'strong') {
+    return <MDStrong node={node} />;
+  }
+  if (node.children.length === 1 && node.children[0].tagName === 'em') {
+    return <MDItalic node={node} />;
+  }
   if (node.children.length === 1 && node.children[0].tagName === 'a') {
     return <LinkComponent node={node} />;
   }

--- a/src/components/markdown-styling/components/MDStrong.js
+++ b/src/components/markdown-styling/components/MDStrong.js
@@ -1,0 +1,10 @@
+import { Stack, Typography } from '@mui/material';
+
+export const MDStrong = ({ node }) => {
+  const str = node?.children[0].children[0]?.value || '';
+  return (
+    <Stack data-testid="MDStrong-component">
+      <Typography fontWeight={'700'}>{str}</Typography>
+    </Stack>
+  );
+};

--- a/src/components/markdown-styling/components/index.js
+++ b/src/components/markdown-styling/components/index.js
@@ -5,3 +5,5 @@ export * from './MDBlockquote';
 export * from './MDParagraph';
 export * from './MDImage';
 export * from './MDCodeBlock';
+export * from './MDStrong';
+export * from './MDItalic';

--- a/test/__tests__/components/markdown-styling/ZestyMarkdownParser.test.js
+++ b/test/__tests__/components/markdown-styling/ZestyMarkdownParser.test.js
@@ -10,6 +10,8 @@ import {
   MDCodeBlock,
   MDImage,
   MDBlockquote,
+  MDStrong,
+  MDItalic,
 } from '../../../../src/components/markdown-styling/components';
 
 describe('MDH3', () => {
@@ -273,5 +275,56 @@ describe('MDBlockquote', () => {
     expect(boxElement).toBeInTheDocument();
 
     expect(boxElement).toMatchSnapshot();
+  });
+});
+
+describe('MDStrong', () => {
+  it('renders the text with the correct fontWeight', () => {
+    const mockNode = {
+      children: [
+        {
+          children: [
+            {
+              value: 'Hello, World!',
+            },
+          ],
+        },
+      ],
+    };
+    const { getByText, getByTestId } = render(<MDStrong node={mockNode} />);
+    const strongText = getByText('Hello, World!');
+    expect(strongText).toBeInTheDocument();
+    expect(strongText).toHaveStyle('font-weight: 700');
+
+    const boxelement = getByTestId('MDStrong-component');
+    expect(boxelement).toBeInTheDocument();
+
+    expect(boxelement).toMatchSnapshot();
+  });
+});
+
+describe('MDItalic', () => {
+  it('renders the text with the correct fontStyle and fontWeight', () => {
+    const mockNode = {
+      children: [
+        {
+          children: [
+            {
+              value: 'Hello, World!',
+            },
+          ],
+        },
+      ],
+    };
+    const { getByText, getByTestId } = render(<MDItalic node={mockNode} />);
+    const italicText = getByText('Hello, World!');
+    expect(italicText).toBeInTheDocument();
+    expect(italicText).toHaveStyle('font-style: italic');
+    expect(italicText).toHaveStyle('font-weight: 400');
+
+    const boxelement = getByTestId('MDItalic-component');
+    expect(boxelement).toBeInTheDocument();
+
+    expect(boxelement).toMatchSnapshot();
   });
 });

--- a/test/__tests__/components/markdown-styling/__snapshots__/ZestyMarkdownParser.test.js.snap
+++ b/test/__tests__/components/markdown-styling/__snapshots__/ZestyMarkdownParser.test.js.snap
@@ -260,10 +260,36 @@ exports[`MDImage should render MDSmallImage if node does not have title 1`] = `
 </div>
 `;
 
+exports[`MDItalic renders the text with the correct fontStyle and fontWeight 1`] = `
+<div
+  class="css-nen11g-MuiStack-root"
+  data-testid="MDItalic-component"
+>
+  <p
+    class="MuiTypography-root MuiTypography-body1 css-c83ayk-MuiTypography-root"
+  >
+    Hello, World!
+  </p>
+</div>
+`;
+
 exports[`MDParagraph should render the MDParagraph component with correct content and links 1`] = `
 <p
   data-testid="box-container"
 >
   By using URL parameters, businesses can craft dyna… possibilities for enhancing the user experience.
 </p>
+`;
+
+exports[`MDStrong renders the text with the correct fontWeight 1`] = `
+<div
+  class="css-nen11g-MuiStack-root"
+  data-testid="MDStrong-component"
+>
+  <p
+    class="MuiTypography-root MuiTypography-body1 css-ndaqpv-MuiTypography-root"
+  >
+    Hello, World!
+  </p>
+</div>
 `;


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

- added parse for bold and italics

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list the simulator and android emulators used.

- [x] Manual Test
- [x] Unit Test
- [ ] E2E Test

# Screenshots / Screen recording
Please add screenshots or recording if applicable
![image](https://github.com/zesty-io/website/assets/71545960/fec80f62-dc3a-487f-ab25-388ee340b4a2)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
