### PR TITLE
fix(algosearch): add box to show page instead of arrow in the search …

### DIFF
--- a/src/views/Docs/AlgoSearch.js
+++ b/src/views/Docs/AlgoSearch.js
@@ -272,6 +272,7 @@ const CustomizedTreeView = ({ hit }) => {
             </Box>
           </Box>
         )}
+        <Box></Box>
       </StyledTreeItem>
     </TreeView>
   );


### PR DESCRIPTION
Add Empty box to appear the content is page instead of a link

![image](https://github.com/zesty-io/website/assets/61284357/8bdf6abd-fcad-4a36-9300-1929b39ed747)
