### PR TITLE
feat(homepage): use next/image component for images and fix lighthous…

### DIFF
--- a/src/revamp/ui/EnterpriseGrowth/index.js
+++ b/src/revamp/ui/EnterpriseGrowth/index.js
@@ -3,6 +3,7 @@ import Marquee from 'react-fast-marquee';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 import { generateAlt } from 'utils';
+import Image from 'next/image';
 
 const alphaUniverse = 'https://kfg6bckb.media.zestyio.com/alphaUniverse.webp',
   sonyLogo = 'https://kfg6bckb.media.zestyio.com/sonyLogo.svg',
@@ -108,7 +109,7 @@ const EnterpriseGrowth = ({
           </Typography>
           <Typography
             color="white"
-            variant="h1"
+            variant="h2"
             fontWeight={800}
             letterSpacing="-0.02em"
             mb={3}
@@ -221,40 +222,31 @@ const EnterpriseGrowth = ({
                 sx={{ cursor: 'pointer' }}
                 onClick={() => (window.location.href = c.link)}
               >
-                <Box
-                  alt={generateAlt('')}
-                  component="img"
-                  loading="lazy"
-                  width="100%"
-                  height="auto"
+                <Image
                   src={c.mainImage}
-                  sx={(theme) => ({
-                    [theme.breakpoints.up('xs')]: {
-                      objectFit: 'contain',
-                      marginBottom: '24px',
-                      borderRadius: '6px',
-                    },
-                    [theme.breakpoints.up('lg')]: {
-                      height: '344px',
-                    },
-                  })}
+                  loading="lazy"
+                  alt={generateAlt('')}
+                  width={707}
+                  height={400}
                 />
 
                 <Box
                   component="img"
                   loading="lazy"
                   alt={generateAlt('')}
+                  width={120}
                   height={{ xs: '32px', tablet: '64px' }}
                   src={c.logo}
                   sx={{
                     objectFit: 'contain',
                     alignSelf: 'start',
                     marginBottom: '12px',
+                    marginTop: 2,
                   }}
                 />
 
                 <Typography
-                  variant="h4"
+                  variant="h3"
                   letterSpacing="-0.02em"
                   color="white"
                   fontWeight={800}

--- a/src/revamp/ui/FeatureBulletWithTestimonials/index.js
+++ b/src/revamp/ui/FeatureBulletWithTestimonials/index.js
@@ -1,6 +1,7 @@
 import { Box, Divider, Stack, Typography } from '@mui/material';
 import { CheckRounded as CheckRoundedIcon } from '@mui/icons-material';
 import { generateAlt } from 'utils';
+import Image from 'next/image';
 
 const featureContent = 'https://kfg6bckb.media.zestyio.com/supportImage.webp',
   logo = 'https://kfg6bckb.media.zestyio.com/experiom.png';
@@ -116,10 +117,6 @@ const FeatureBulletWithTestimonials = ({
         order={{ lg: isImageRight ? 1 : 0 }}
       >
         <Box
-          component="img"
-          alt={generateAlt('')}
-          loading="lazy"
-          src={image}
           sx={(theme) => ({
             [theme.breakpoints.up('xs')]: {
               objectFit: 'contain',
@@ -147,7 +144,15 @@ const FeatureBulletWithTestimonials = ({
               height: '100%',
             },
           })}
-        />
+        >
+          <Image
+            src={image}
+            loading="lazy"
+            alt={generateAlt('')}
+            width={788}
+            height={420}
+          />
+        </Box>
       </Stack>
     </Stack>
   );

--- a/src/revamp/ui/GetDemoSection/index.js
+++ b/src/revamp/ui/GetDemoSection/index.js
@@ -271,6 +271,7 @@ const GetDemoSection = ({
                 <Form id="site-form" onSubmit={handleSubmit}>
                   <Stack>
                     <Typography
+                      component={'p'}
                       variant="h4"
                       letterSpacing="-0.02em"
                       color="text.primary"

--- a/src/revamp/ui/GridFeature/index.js
+++ b/src/revamp/ui/GridFeature/index.js
@@ -213,7 +213,12 @@ const GridFeature = ({
                 height={240}
                 style={{ objectFit: 'contain' }}
               />
-              <Typography fontWeight={600} letterSpacing="-0.02em" variant="h5">
+              <Typography
+                fontWeight={600}
+                letterSpacing="-0.02em"
+                variant="h5"
+                component={'p'}
+              >
                 {feature.title}
               </Typography>
               <Typography color="text.secondary">

--- a/src/revamp/ui/HeroV2/index.js
+++ b/src/revamp/ui/HeroV2/index.js
@@ -3,6 +3,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 import { generateAlt } from 'utils';
 import { useEffect, useState } from 'react';
+import Image from 'next/image';
 
 const media =
     'https://kfg6bckb.media.zestyio.com/Zesty-io-2023-Homepage-Graphic.png',
@@ -128,7 +129,7 @@ const Hero = ({
                   key={index}
                   py={0}
                   variant="h1"
-                  color={index === currentTextIndex ? '' : '#ccc'}
+                  color={index === currentTextIndex ? '' : '#474747'}
                   fontWeight={index === currentTextIndex ? 800 : 400}
                   fontSize={{ xs: 24, sm: 32, tablet: '62px' }}
                   lineHeight={{ xs: '18px', sm: '32px', tablet: '56px' }}
@@ -212,7 +213,7 @@ const Hero = ({
               columnGap="20px"
             >
               {logos.map((image, index) => (
-                <img
+                <Image
                   key={index}
                   loading="lazy"
                   src={image.src}
@@ -229,12 +230,6 @@ const Hero = ({
       </Container>
 
       <Box
-        component="img"
-        // loading="lazy"
-        src={media}
-        alt="Zesty Image"
-        width="auto"
-        height="auto"
         sx={(theme) => ({
           [theme.breakpoints.up('lg')]: {
             position: 'absolute',
@@ -267,7 +262,17 @@ const Hero = ({
             width: '100%',
           },
         })}
-      />
+      >
+        <Image
+          blurDataURL={`${media}?blur=50&optimize=high`}
+          placeholder="blur"
+          priority
+          alt="Zesty Image"
+          width={1500}
+          height={950}
+          src={`${media}?width=1500&height=950`}
+        />
+      </Box>
     </Box>
   );
 };

--- a/src/revamp/ui/SecurityFeature/index.js
+++ b/src/revamp/ui/SecurityFeature/index.js
@@ -1,4 +1,5 @@
 import { Box, Stack, Typography } from '@mui/material';
+import Image from 'next/image';
 
 const featureContent =
   'https://kfg6bckb.media.zestyio.com/certified-security-compliance.webp';
@@ -61,10 +62,6 @@ const SecurityFeature = ({
       </Stack>
       <Stack order={{ xs: 2, lg: 1 }}>
         <Box
-          component="img"
-          alt="zesty-image"
-          loading="lazy"
-          src={image}
           sx={(theme) => ({
             [theme.breakpoints.up('xs')]: {
               objectFit: 'contain',
@@ -92,7 +89,15 @@ const SecurityFeature = ({
               height: '420px',
             },
           })}
-        />
+        >
+          <Image
+            src={image}
+            loading="lazy"
+            alt="zesty-image"
+            width={700}
+            height={420}
+          />
+        </Box>
       </Stack>
     </Stack>
   );

--- a/src/revamp/ui/SingleTestimonial/index.js
+++ b/src/revamp/ui/SingleTestimonial/index.js
@@ -1,6 +1,7 @@
 import { Box, Stack, Typography } from '@mui/material';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
+import Image from 'next/image';
 
 const witnessImage = 'https://kfg6bckb.media.zestyio.com/Ben.webp',
   witnessLogo =
@@ -73,11 +74,6 @@ When working with clients like Sony, we need to be using secure, enterprise-grad
           }}
         >
           <Box
-            component="img"
-            loading="lazy"
-            src={witness}
-            alt="zesty-image"
-            borderRadius="50%"
             sx={(theme) => ({
               [theme.breakpoints.up('xs')]: {
                 objectFit: 'contain',
@@ -94,8 +90,17 @@ When working with clients like Sony, we need to be using secure, enterprise-grad
                 height: '363px',
               },
             })}
-          />
-          <Typography variant="h5" color="white" fontWeight={600}>
+          >
+            <Image
+              style={{ borderRadius: '50%' }}
+              src={witness}
+              loading="lazy"
+              alt="zesty-image"
+              width={303}
+              height={280}
+            />
+          </Box>
+          <Typography variant="h5" component="p" color="white" fontWeight={600}>
             {name}
           </Typography>
           <Typography color="white" fontWeight={700} mb="20px">

--- a/src/revamp/ui/Stats/index.js
+++ b/src/revamp/ui/Stats/index.js
@@ -7,8 +7,9 @@ import {
 } from '@mui/icons-material';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
+import Image from 'next/image';
 
-const contentStats = 'https://kfg6bckb.media.zestyio.com/fall.svg';
+const contentStats = 'https://kfg6bckb.media.zestyio.com/g2fall.png';
 
 const statsArray = [
   {
@@ -90,28 +91,12 @@ const Stats = ({
           }}
           margin="0 auto"
         >
-          <Box
-            component="img"
-            loading="lazy"
-            alt="zesty-image"
+          <Image
             src={contentStats}
-            style={{ objectFit: 'contain' }}
-            sx={(theme) => ({
-              [theme.breakpoints.up('xs')]: {
-                margin: '0 auto',
-                width: '100%',
-                height: '100%',
-              },
-              [theme.breakpoints.up('tablet')]: {
-                width: '410.71px',
-                height: '317px',
-              },
-
-              [theme.breakpoints.up('md')]: {
-                width: '100%',
-                height: '100%',
-              },
-            })}
+            loading="lazy"
+            alt="Zesty Image"
+            width={505}
+            height={317}
           />
         </Box>
       </Stack>

--- a/src/revamp/ui/TabsSection/TabSection.js
+++ b/src/revamp/ui/TabsSection/TabSection.js
@@ -5,6 +5,7 @@ import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTheme } from '@mui/material/styles';
 
 import React from 'react';
+import Image from 'next/image';
 
 const listItems = [
   'Tortor interdum condimentum nunc molestie quam',
@@ -44,10 +45,6 @@ const TabSection = ({
       >
         <Stack order={isLG ? 2 : 1}>
           <Box
-            component="img"
-            loading="lazy"
-            alt="zesty-image"
-            src={image}
             sx={(theme) => ({
               [theme.breakpoints.up('xs')]: {
                 objectFit: 'contain',
@@ -74,7 +71,17 @@ const TabSection = ({
                 height: '420px',
               },
             })}
-          />
+          >
+            <Image
+              placeholder="blur"
+              blurDataURL={`${image}?blur=50&optimize=high`}
+              loading="lazy"
+              alt="Zesty Image"
+              width={700}
+              height={420}
+              src={`${image}?width=700&height=420}`}
+            />
+          </Box>
         </Stack>
 
         <Stack order={isLG ? 1 : 2} justifyContent="center" mr={isLG ? 8 : 0}>

--- a/src/revamp/ui/TabsSection/index.js
+++ b/src/revamp/ui/TabsSection/index.js
@@ -123,7 +123,7 @@ function TabPanel(props) {
 }
 
 const TabsSection = ({
-  header = 'Personalization, A/B, Integrated Analytics, Any Business Configuration',
+  header = 'Personalization, A/B Testing, Integrated Analytics, Any Business Configuration',
 }) => {
   const [value, setValue] = useState('Content');
 
@@ -202,6 +202,9 @@ const TabsSection = ({
         >
           {tabLists.map((tab) => (
             <Tab
+              aria-selected={value === tab.name}
+              role="tab"
+              aria-controls={tab.name}
               key={tab.name}
               label={tab.name}
               value={tab.name}


### PR DESCRIPTION
Update Image to use next/image component
Fix image ratios add placeholder blur and lazy loading
adjust proper html semantics
adjust text color for better contrast


Beta - Before Update
![Screenshot 2023-09-22 at 12 58 15 AM](https://github.com/zesty-io/website/assets/61284357/9a84c4eb-7505-4d6c-92d6-f8eaff9a1f66)


Beta - After Update

![Screenshot 2023-09-22 at 1 12 05 AM](https://github.com/zesty-io/website/assets/61284357/1ac70c85-48ca-4522-94c4-0a7b703dfe66)

