### PR TITLE
fix(zestyhead): og image not showing in facebook debugger

### DIFF
--- a/src/components/globals/ZestyHead.js
+++ b/src/components/globals/ZestyHead.js
@@ -29,7 +29,11 @@ export default function ZestyHead({ content }) {
   const isBlog = router.asPath.includes('mindshare') ? true : false;
   const title = content.meta?.web?.seo_meta_title;
   const description = content.meta?.web.seo_meta_description;
-  const preview = ogimage;
+
+  const preview = ogimage.replace(
+    'kfg6bckb.media.zestyio.com',
+    'kfg6bckb.media.zesty.site',
+  );
   const type = isBlog ? 'article' : 'website';
 
   return (


### PR DESCRIPTION
# Description



Closes #2107 
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- [x] Manual Test
- [ ] Unit Test
- [ ] E2E Test

# Screenshots / Screen recording
Please add screenshots or recording if applicable
https://developers.facebook.com/tools/debug/?q=https%3A%2F%2Fbeta.zesty.io%2Fmindshare%2Fcontent-marketing-world-2023%2F
<img width="1070" alt="image" src="https://github.com/zesty-io/website/assets/71545960/902539f7-5231-47b7-995c-a41cadaeaff8">

