### PR TITLE
fix: fix margin spacing on img before a heading & img redirects

### DIFF
--- a/src/views/zesty/Article.js
+++ b/src/views/zesty/Article.js
@@ -530,6 +530,17 @@ function Article({ content }) {
                     component: Link,
                     props: {
                       color: 'info.main',
+                      sx: {
+                        '& > span > span:has(img)': {
+                          height: '100%',
+                          display: 'inline-block',
+                          width: '100%',
+                        },
+                        '& > span > span > img': {
+                          cursor: 'pointer',
+                          pointerEvents: 'none',
+                        },
+                      },
                     },
                   },
                   sub: {

--- a/src/views/zesty/Article.js
+++ b/src/views/zesty/Article.js
@@ -218,6 +218,9 @@ function Article({ content }) {
                           mx: 'auto',
                           px: 0,
                         },
+                        '& + p > span > span > img': {
+                          mt: '20px !important',
+                        },
                       }),
                     },
                   },
@@ -244,6 +247,9 @@ function Article({ content }) {
                           mx: 'auto',
                           px: 0,
                         },
+                        '& + p > span > span > img': {
+                          mt: '20px !important',
+                        },
                       }),
                     },
                   },
@@ -268,6 +274,9 @@ function Article({ content }) {
                           width: '640px',
                           mx: 'auto',
                           px: 0,
+                        },
+                        '& + p > span > span > img': {
+                          mt: '20px !important',
                         },
                       }),
                     },
@@ -294,6 +303,9 @@ function Article({ content }) {
                           mx: 'auto',
                           px: 0,
                         },
+                        '& + p > span > span > img': {
+                          mt: '20px !important',
+                        },
                       }),
                     },
                   },
@@ -319,6 +331,9 @@ function Article({ content }) {
                           mx: 'auto',
                           px: 0,
                         },
+                        '& + p > span > span > img': {
+                          mt: '20px !important',
+                        },
                       }),
                     },
                   },
@@ -343,6 +358,9 @@ function Article({ content }) {
                           width: '640px',
                           mx: 'auto',
                           px: 0,
+                        },
+                        '& + p > span > span > img': {
+                          mt: '20px !important',
                         },
                       }),
                     },


### PR DESCRIPTION
fix margin spacing on img before a heading

# Screenshots / Screen recording
Please add screenshots or recording if applicable

[screencast-test.zesty.io_3000-2023.11.29-21_20_52.webm](https://github.com/zesty-io/website/assets/44116036/a0c2c25e-f0bf-4371-a0cb-9cfc0ea4bfa3)

