### PR TITLE
feat(articlesjs): create a shortcode to render custom react component…

### DIFF
--- a/src/views/zesty/Article.js
+++ b/src/views/zesty/Article.js
@@ -31,7 +31,7 @@
  */
 
 import React from 'react';
-import { Box, Link, Table, useTheme } from '@mui/material';
+import { Box, Button, Link, Table, useTheme } from '@mui/material';
 import FillerContent from 'components/globals/FillerContent';
 import {
   List,
@@ -91,6 +91,9 @@ function Article({ content }) {
     link: c?.meta?.web?.uri,
   }));
 
+  // Define a regular expression pattern to match [_CTA_]
+  let regexPattern = /\[CALL TO ACTION\]/g;
+
   useEffect(() => {
     const validateWysiwyg = () => {
       if (newContent?.includes('Error hydrating')) {
@@ -109,7 +112,12 @@ function Article({ content }) {
       txt.innerHTML = str;
       return txt.value;
     }
-    setNewContent(decode(validateWysiwyg()));
+    setNewContent(
+      decode(validateWysiwyg()).replace(
+        regexPattern,
+        '<acronym title="Call to Action"></acronym>',
+      ),
+    );
   }, []);
 
   const MyZoomImg = ({ _children, ...props }) => (
@@ -154,6 +162,15 @@ function Article({ content }) {
             <MuiMarkdown
               options={{
                 overrides: {
+                  acronym: {
+                    component: CtaComponent,
+                    props: {
+                      title: content?.cta_title,
+                      description: content?.cta_description,
+                      ctaText: content?.cta_text,
+                      ctaLink: content?.cta_link,
+                    },
+                  },
                   p: {
                     component: Typography,
                     props: {
@@ -580,3 +597,57 @@ function Article({ content }) {
 }
 
 export default Article;
+
+function CtaComponent({ title, description, ctaText, ctaLink }) {
+  return (
+    <>
+      {title && description && (
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            padding: 4,
+            gap: 2,
+            justifyContent: 'center',
+            alignItems: 'center',
+            height: 'auto',
+            width: '100%',
+            backgroundColor: '#f0f0f0',
+            borderRadius: '8px',
+            boxShadow: '0px 4px 8px rgba(0, 0, 0, 0.1)',
+            textAlign: 'center',
+          }}
+        >
+          <Typography variant="h5" fontWeight={700} color="primary">
+            {title || ''}
+          </Typography>
+          <MuiMarkdown
+            options={{
+              overrides: {
+                p: {
+                  component: Typography,
+                  props: {
+                    variant: 'body1',
+                    color: 'text.secondary',
+                  },
+                },
+              },
+            }}
+          >
+            {description || ''}
+          </MuiMarkdown>
+
+          <Button
+            target="_blank"
+            href={ctaLink || ''}
+            component="a"
+            variant="contained"
+            color="primary"
+          >
+            {ctaText || ''}
+          </Button>
+        </Box>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
Issue: marketing team needs a way to add cta components in between article content
Description: Created a shortcode from article wysiwyg that will render a custom CTA components.


ShortCode: [CALL TO ACTION]
![image](https://github.com/zesty-io/website/assets/61284357/6ba82f49-74f3-4873-bab6-dc5987ebb930)

Sample output
![image](https://github.com/zesty-io/website/assets/61284357/be846515-a07f-4ca3-9df5-1fd4c9dd41ee)

Data Fields

![image](https://github.com/zesty-io/website/assets/61284357/1eec8bc6-0081-48e9-8f58-247fc17be963)
