### PR TITLE
feat(slug): modify the env for algolia search api key

### DIFF
--- a/src/pages/[[...zesty]].js
+++ b/src/pages/[[...zesty]].js
@@ -119,7 +119,7 @@ export async function getServerSideProps({ req, res, resolvedUrl }) {
       docs,
     },
     algolia: {
-      apiKey: process.env.ALGOLIA_APIKEY,
+      apiKey: process.env.ALGOLIA_SEARCH_KEY,
       appId: process.env.ALGOLIA_APPID,
       index: process.env.ALGOLIA_INDEX,
     },


### PR DESCRIPTION
Algolia Doc search isn't working on docs/... path because the apikey is point to old algolia index.