### PR TITLE
fix(demo.js): optimize demos page for tablet views

### DIFF
--- a/src/views/zesty/Demo.js
+++ b/src/views/zesty/Demo.js
@@ -80,7 +80,11 @@ function EngageTypeCards({ cardData }) {
         </Typography>
       </Stack>
 
-      <Grid container spacing={4} sx={{ width: '100%', maxWidth: 1200 }}>
+      <Grid
+        container
+        spacing={{ xs: 4, sm: 1, md: 4 }}
+        sx={{ width: '100%', maxWidth: 1200 }}
+      >
         {cardData?.map((item) => {
           return (
             <Grid
@@ -90,11 +94,11 @@ function EngageTypeCards({ cardData }) {
               sx={{ textDecoration: 'none' }}
               item
               xs={12}
-              md={4}
+              sm={4}
             >
               <Stack
                 height={'100%'}
-                minHeight={220}
+                minHeight={250}
                 component={Card}
                 sx={{
                   '&:hover': {
@@ -147,7 +151,10 @@ function EngageTypeCards({ cardData }) {
                             p: {
                               component: Typography,
                               props: {
-                                sx: { textAlign: 'left' },
+                                sx: {
+                                  textAlign: 'left',
+                                  fontSize: { sm: 14, md: 'unset' },
+                                },
                                 color: 'text.secondary',
                               },
                             },


### PR DESCRIPTION
Description: Optimize Demos page for 810x1080 viewport or tablet views


![image](https://github.com/zesty-io/website/assets/61284357/67d5eecd-072f-4e3b-b11a-2a39d8174a6b)
