### PR TITLE
fix: algolia search sorting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,6 @@
    "editor.formatOnSave": true,
    "editor.defaultFormatter": "esbenp.prettier-vscode",
    "editor.codeActionsOnSave": {
-      "source.fixAll.format": false
+      "source.fixAll.format": "never"
    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,6 @@
    "editor.formatOnSave": true,
    "editor.defaultFormatter": "esbenp.prettier-vscode",
    "editor.codeActionsOnSave": {
-      "source.fixAll.format": "never"
+      "source.fixAll.format": false
    }
 }

--- a/src/pages/docs/index.js
+++ b/src/pages/docs/index.js
@@ -208,6 +208,9 @@ export function DocSearchModal() {
   return (
     <DocSearch
       transformItems={(items) => {
+        /*
+         * Group items by hierarchy and remove items without hierarchy
+         */
         const groupBy = items.reduce((acc, item) => {
           if (!item.hierarchy) {
             return acc;
@@ -220,10 +223,36 @@ export function DocSearchModal() {
           };
         }, {});
 
-        return Object.keys(groupBy).map((level) => ({
+        /**
+         * Group based on parent page
+         */
+        const groups = Object.keys(groupBy).map((level) => ({
           items: groupBy[level],
-          level,
         }));
+
+        const groupItems = groups?.[0]?.items || [];
+
+        /**
+         * Find the parent page from groupItems
+         */
+        const parent = groupItems?.find((item) => {
+          if (
+            item.hierarchy.lvl1 !== null &&
+            item.hierarchy.lvl2 == null &&
+            item.hierarchy.lvl3 == null &&
+            item.hierarchy.lvl4 == null &&
+            item.hierarchy.lvl5 == null &&
+            item.hierarchy.lvl6 == null
+          ) {
+            return item;
+          }
+        });
+
+        /**
+         * find the index of the parent from groupItems and put it in the first index
+         */
+        const parentIndex = groupItems?.indexOf(parent);
+        return groupItems.splice(parentIndex, 1).concat(groupItems);
       }}
       placeholder="Search docs..."
       maxResultsPerGroup={100}

--- a/src/pages/docs/index.js
+++ b/src/pages/docs/index.js
@@ -207,8 +207,23 @@ export function DocSearchModal() {
 
   return (
     <DocSearch
-      transformItems={(item) => {
-        return item.reverse();
+      transformItems={(items) => {
+        const groupBy = items.reduce((acc, item) => {
+          if (!item.hierarchy) {
+            return acc;
+          }
+          const list = acc[item.hierarchy.lvl1] || [];
+
+          return {
+            ...acc,
+            [item.hierarchy.lvl1]: list.concat(item),
+          };
+        }, {});
+
+        return Object.keys(groupBy).map((level) => ({
+          items: groupBy[level],
+          level,
+        }));
       }}
       placeholder="Search docs..."
       maxResultsPerGroup={100}


### PR DESCRIPTION
# Description

Algolia DocSearc, prioritize all parents pages over contents and sort them according to their parents if exist

![image](https://github.com/zesty-io/website/assets/61284357/4733fee6-9bc0-4622-a5e2-7585ed49861c)

![image](https://github.com/zesty-io/website/assets/61284357/3cbf07e6-9dcc-41a9-bf1c-b4fe3e2663bb)


Closes #2207 