### PR TITLE
style: update styling for mindshare article cta component

### DIFF
--- a/src/views/zesty/Article.js
+++ b/src/views/zesty/Article.js
@@ -686,7 +686,7 @@ function CtaComponent({ title, description, ctaText, ctaLink }) {
                   },
                 },
                 span: {
-                    component: Typography,
+                  component: Typography,
                   props: {
                     variant: 'body1',
                     color: '#D0D5DD',

--- a/src/views/zesty/Article.js
+++ b/src/views/zesty/Article.js
@@ -678,8 +678,15 @@ function CtaComponent({ title, description, ctaText, ctaLink }) {
           <MuiMarkdown
             options={{
               overrides: {
-                span: {
+                p: {
                   component: Typography,
+                  props: {
+                    variant: 'body1',
+                    color: '#D0D5DD',
+                  },
+                },
+                span: {
+                    component: Typography,
                   props: {
                     variant: 'body1',
                     color: '#D0D5DD',


### PR DESCRIPTION
Added p tag to the override props to apply color styling for the description:

From:
![Screenshot 2024-01-25 051952](https://github.com/zesty-io/website/assets/70579069/9d3f2fdd-7c96-4511-a82e-110e927007a3)

To:
![Screenshot 2024-01-25 052010](https://github.com/zesty-io/website/assets/70579069/ba5a4332-7bf2-4a46-8eab-4cc418b631b7)

