### PR TITLE
fix: mindshare related articles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zesty-website",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zesty-website",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.1",
         "@codemirror/view": "^6.21.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zesty-website",
   "author": "Zesty.io Platform Inc.",
   "email": "marketing@zesty.io",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",

--- a/src/views/zesty/Article.js
+++ b/src/views/zesty/Article.js
@@ -120,7 +120,7 @@ function Article({ content }) {
     setRelatedArticles(
       getRelatedArticles(content?.related_articles, latestArticles),
     );
-  }, []);
+  }, [latestArticles]);
 
   const verifyPathnameInCookie = (path) => {
     if (!hasCookie(cookieName)) {

--- a/src/views/zesty/Article.js
+++ b/src/views/zesty/Article.js
@@ -150,7 +150,7 @@ function Article({ content }) {
     let result;
 
     if (related?.data?.length > 4) {
-      totalSliceCount = related.length;
+      totalSliceCount = related.data.length;
       latest = [];
     }
 


### PR DESCRIPTION
**ISSUES:**

1. Not showing related article(s) based on content from the manager
![image](https://github.com/zesty-io/website/assets/70579069/f90784bd-6d34-48ce-bf5e-ffe902ae484b)
![image](https://github.com/zesty-io/website/assets/70579069/ee3b9ed5-953c-4c10-876d-65bf692b0f2b)

2. Current article is showing in the related articles section
![image](https://github.com/zesty-io/website/assets/70579069/e09505a3-9720-4f10-a849-ed461ab99392)
![Screenshot 2024-01-30 021422](https://github.com/zesty-io/website/assets/70579069/631df9e6-f151-4b04-8c71-621c3cb7eb59)


**FIXED:** 
Prioritized to render (if there's any) related articles from content. Otherwise render the latest articles excluding the current article page.


https://github.com/zesty-io/website/assets/70579069/b1db6a37-e6f2-41aa-ba68-e7516bf93879



