### PR TITLE
fix: render the news letter subscription by default

### DIFF
--- a/src/components/marketing/PopupLeadCapture/PopUpForm.js
+++ b/src/components/marketing/PopupLeadCapture/PopUpForm.js
@@ -227,6 +227,7 @@ export default function PopUpForm({
                         />
                       </Box>
                       <Button
+                        id="gated-popup-modal"
                         variant="contained"
                         sx={{ width: '100%' }}
                         color="secondary"

--- a/src/views/zesty/Article.js
+++ b/src/views/zesty/Article.js
@@ -692,7 +692,7 @@ function Article({ content }) {
       </ThemeProvider>
 
       {(content?.enable_newsletter_subscription === null ||
-        content?.enable_newsletter_subscription === '1') && (
+        content?.enable_newsletter_subscription == '1') && (
         <Container position="relative" zIndex={3}>
           <CtaWithInputField
             title={'Subscribe to the zestiest newsletter in the industry'}

--- a/src/views/zesty/Article.js
+++ b/src/views/zesty/Article.js
@@ -120,6 +120,7 @@ function Article({ content }) {
     setRelatedArticles(
       getRelatedArticles(content?.related_articles, latestArticles),
     );
+    console.log(content);
   }, [latestArticles]);
 
   const verifyPathnameInCookie = (path) => {
@@ -690,15 +691,18 @@ function Article({ content }) {
         </Stack>
       </ThemeProvider>
 
-      <Container position="relative" zIndex={3}>
-        <CtaWithInputField
-          title={'Subscribe to the zestiest newsletter in the industry'}
-          description={
-            'Get the latest from the Zesty team, from whitepapers to product updates.'
-          }
-          cta={'Subscribe'}
-        />
-      </Container>
+      {(content?.enable_newsletter_subscription === null ||
+        content?.enable_newsletter_subscription === '1') && (
+        <Container position="relative" zIndex={3}>
+          <CtaWithInputField
+            title={'Subscribe to the zestiest newsletter in the industry'}
+            description={
+              'Get the latest from the Zesty team, from whitepapers to product updates.'
+            }
+            cta={'Subscribe'}
+          />
+        </Container>
+      )}
 
       {/* Side PopUp */}
       {showPopup && <PopUpLeadCapture {...popupLeadCaptureProps} />}


### PR DESCRIPTION
# Description

Render the newsletter subscription component on all articles by default, but allow deactivation in the manager. This is true when _enable_newsletter_subscription_ field is equal to **null** or **1**.

Fixes #2342

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Created new article:

- set the value of _enable_newsletter_subscription_ to **null** (render the component)
- set the value of _enable_newsletter_subscription_ to **1** (render the component)
- set the value of _enable_newsletter_subscription_ to **0** (does not render the component)


- [x] Manual Test

# Screenshots / Screen recording
![Screenshot 2024-02-03 045907](https://github.com/zesty-io/website/assets/70579069/ee8b9258-5e01-41da-9283-33f00cdd4bb5)
![Screenshot 2024-02-03 050123](https://github.com/zesty-io/website/assets/70579069/4f7d8302-a80d-4314-a325-974270c3bfe7)
![Screenshot 2024-02-03 050010](https://github.com/zesty-io/website/assets/70579069/d3841491-066e-48af-b6c0-75824cada685)


