### PR TITLE
fix: demo cards alignment

### DIFF
--- a/src/views/zesty/Demo.js
+++ b/src/views/zesty/Demo.js
@@ -65,7 +65,6 @@ function EngageTypeCards({ cardData }) {
       px={{ xs: 2, tablet: 4, lg: 14 }}
       alignItems="center"
       justifyContent="center"
-      textAlign="center"
     >
       <Stack mb={{ xs: 4, lg: 5 }}>
         <Typography
@@ -85,6 +84,7 @@ function EngageTypeCards({ cardData }) {
         container
         spacing={{ xs: 4, sm: 1, md: 4 }}
         sx={{ width: '100%', maxWidth: 1200 }}
+        justifyContent="center"
       >
         {cardData?.map((item) => {
           return (

--- a/src/views/zesty/Demo.js
+++ b/src/views/zesty/Demo.js
@@ -65,6 +65,7 @@ function EngageTypeCards({ cardData }) {
       px={{ xs: 2, tablet: 4, lg: 14 }}
       alignItems="center"
       justifyContent="center"
+      textAlign="center"
     >
       <Stack mb={{ xs: 4, lg: 5 }}>
         <Typography


### PR DESCRIPTION
# Description

Fixed the alignment of cads in `/demo` page

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Manual Test

# Screenshots / Screen recording

**BEFORE:** 
![image](https://github.com/zesty-io/website/assets/70579069/3b91beb2-2247-49f7-8b39-fd9b510ac96a)

**AFTER:**
![image](https://github.com/zesty-io/website/assets/70579069/9394f0d3-e276-48c7-9666-2694b0da4dce)
