### PR TITLE
fix: fly navigation sub items order

### DIFF
--- a/src/components/globals/constants.js
+++ b/src/components/globals/constants.js
@@ -3963,7 +3963,7 @@ export const flyoutNavigation = [
               },
             ],
           },
-          sort_order: '1',
+          sort_order: '3',
           main_or_blue_secondary_item: '1',
         },
         {
@@ -4321,7 +4321,7 @@ export const flyoutNavigation = [
               },
             ],
           },
-          sort_order: '2',
+          sort_order: '1',
           main_or_blue_secondary_item: '1',
         },
         {
@@ -4661,7 +4661,7 @@ export const flyoutNavigation = [
               },
             ],
           },
-          sort_order: '3',
+          sort_order: '2',
           main_or_blue_secondary_item: '1',
         },
       ],

--- a/src/components/globals/constants.js
+++ b/src/components/globals/constants.js
@@ -2709,7 +2709,7 @@ export const flyoutNavigation = [
               },
             ],
           },
-          sort_order: '2',
+          sort_order: '3',
           main_or_blue_secondary_item: '1',
         },
         {
@@ -2964,7 +2964,7 @@ export const flyoutNavigation = [
               },
             ],
           },
-          sort_order: '3',
+          sort_order: '2',
           main_or_blue_secondary_item: '1',
         },
         {
@@ -3003,7 +3003,7 @@ export const flyoutNavigation = [
               },
             ],
           },
-          sort_order: '4',
+          sort_order: '1',
           main_or_blue_secondary_item: '1',
         },
         {


### PR DESCRIPTION
# Description

Re-arrange the fly navigation sub items to a new order

Fixes #2357

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Manual Test

# Screenshots / Screen recording

**OLD ARRANGEMENT:**
![image](https://github.com/zesty-io/website/assets/70579069/3c62d5d4-9d05-411e-8eb0-3ab485915dc3)

**NEW** ARRANGEMENT:
![image](https://github.com/zesty-io/website/assets/70579069/d5682174-4016-4411-b06c-45a91277f888)


