### PR TITLE
fix: distorted images in wysiwyg articles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zesty-website",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zesty-website",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "dependencies": {
         "@codemirror/lang-javascript": "^6.2.1",
         "@codemirror/view": "^6.21.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zesty-website",
   "author": "Zesty.io Platform Inc.",
   "email": "marketing@zesty.io",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "private": true,
   "scripts": {
     "dev": "NODE_OPTIONS='--inspect' next dev",

--- a/src/views/zesty/Article.js
+++ b/src/views/zesty/Article.js
@@ -214,6 +214,11 @@ p img[style*="float:left"],  p img[style*="float: left"] {
 p img[style*="float:right"],  p img[style*="float: right"] {
  width: auto !important;
 }
+
+p img {
+  margin-top: 48px;
+  width: 100%;
+}
 }`;
 
   return (
@@ -475,12 +480,6 @@ p img[style*="float:right"],  p img[style*="float: right"] {
                   },
                   img: {
                     component: 'img',
-                    props: {
-                      style: {
-                        marginTop: '48px',
-                        width: '100%',
-                      },
-                    },
                   },
                   iframe: {
                     component: ({ children, ...props }) => (

--- a/src/views/zesty/Article.js
+++ b/src/views/zesty/Article.js
@@ -55,6 +55,7 @@ import { getCookie, hasCookie, setCookie } from 'cookies-next';
 
 function Article({ content }) {
   const [newContent, setNewContent] = useState(content.article);
+  const [isClient, setIsClient] = useState(false);
   const [relatedArticles, setRelatedArticles] = useState([]);
   const { palette } = useTheme();
 
@@ -120,7 +121,7 @@ function Article({ content }) {
     setRelatedArticles(
       getRelatedArticles(content?.related_articles, latestArticles),
     );
-    console.log(content);
+    setIsClient(true); // set inline styling in client not in server
   }, [latestArticles]);
 
   const verifyPathnameInCookie = (path) => {
@@ -206,20 +207,24 @@ function Article({ content }) {
     setShowPopup,
   };
 
-  const inlineStyles = `
+  const inlineStyles = isClient
+    ? `
 p img[style*="float:left"],  p img[style*="float: left"] {
- width: auto !important;
+  margin-top: 0;
+  width: auto !important;
 }
 
 p img[style*="float:right"],  p img[style*="float: right"] {
- width: auto !important;
+  margin-top: 0;
+  width: auto !important;
 }
 
 p img {
   margin-top: 48px;
   width: 100%;
 }
-}`;
+}`
+    : ``;
 
   return (
     <Box sx={{ position: 'relative' }}>

--- a/src/views/zesty/Article.js
+++ b/src/views/zesty/Article.js
@@ -206,6 +206,16 @@ function Article({ content }) {
     setShowPopup,
   };
 
+  const inlineStyles = `
+p img[style*="float:left"],  p img[style*="float: left"] {
+ width: auto !important;
+}
+
+p img[style*="float:right"],  p img[style*="float: right"] {
+ width: auto !important;
+}
+}`;
+
   return (
     <Box sx={{ position: 'relative' }}>
       <ThemeProvider theme={() => revampTheme(palette.mode)}>
@@ -239,6 +249,7 @@ function Article({ content }) {
               },
             })}
           >
+            <style>{inlineStyles}</style>
             <MuiMarkdown
               options={{
                 overrides: {


### PR DESCRIPTION
# Description

Fix the distorted images when has a style property of `float`. Also, made sure to add the inline styling only in the client side not in the server to avoid hydration issues.

Fixes #2358 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Manual Test

# Screenshots / Screen recording

Please add screenshots or recording if applicable
**ISSUES:** 
![image](https://github.com/zesty-io/website/assets/70579069/fa69e139-8af8-47d6-81ac-dc6320279480)
![image](https://github.com/zesty-io/website/assets/70579069/511598da-07e3-4355-85ea-753cf586d1b0)

**FIX:**
![image](https://github.com/zesty-io/website/assets/70579069/1233ff5b-4db3-4006-a295-59f540513f01)
![image](https://github.com/zesty-io/website/assets/70579069/3ec30c78-5fa5-40fa-9604-a3a88ce528a4)


