### PR TITLE
ci: optimize release scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: Create Release
 
 on:
   push:
-    branches:
-      - production
+    tags:
+      - '*'
 
 jobs:
   create_release:
@@ -16,6 +16,12 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::$(node -e "console.log(require('./package.json').version)")
 
+      - name: Changelog
+        uses: scottbrenner/generate-changelog-action@master
+        id: Changelog
+        env:
+          REPO: ${{ github.repository }}
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -23,6 +29,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.get_version.outputs.VERSION }}
-          release_name: Zesty Website ${{ steps.get_version.outputs.VERSION }}
+          release_name: ${{ steps.get_version.outputs.VERSION }}
           draft: false
           prerelease: false
+          body: |
+            ${{ steps.Changelog.outputs.changelog }}


### PR DESCRIPTION
# Description
- Streamline release processes for improved efficiency.

To publish a release:

- . Locally, use `git push origin --tags`. This action will trigger the create release workflow.
  
This optimized workflow ensures a seamless release process by updating version numbers, committing changes, and triggering the release workflow with a single command.