### PR TITLE
fix: removed zIndex props to fix the issue

### DIFF
--- a/src/blocks/zesty/Bottom/Bottom.js
+++ b/src/blocks/zesty/Bottom/Bottom.js
@@ -73,7 +73,6 @@ const Bottom = ({
                   width: '100%',
                   height: 'auto',
                   position: isLarge ? 'inherit' : 'absolute',
-                  zIndex: 99,
                   bottom: isLarge || !graphic ? 0 : graphicBottom,
                 }}
                 loading="lazy"

--- a/src/blocks/zesty/PageLayouts/Features.js
+++ b/src/blocks/zesty/PageLayouts/Features.js
@@ -112,7 +112,6 @@ const Features = ({
       paddingBottom={isMobile ? 10 : 15}
       sx={{
         position: 'relative',
-        zIndex: '20',
         mt: marginTop,
         background: isDarkMode
           ? theme.palette.zesty.zestyDarkBlue
@@ -281,7 +280,6 @@ const Features = ({
             justifyContent: 'center',
             gap: '4rem',
             position: 'relative',
-            zIndex: '1000',
           }}
         >
           {data?.map((e, i) => {


### PR DESCRIPTION
# Description

Fix incosistent zIndex of marketing website causing it to cover the navigation header.

Fixes #2376

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Manual Test

# Screenshots / Screen recording

**ISSUES:** 
![image](https://github.com/zesty-io/website/assets/70579069/1dfeb297-73cb-4b16-a10a-a2383530272c)
![image](https://github.com/zesty-io/website/assets/70579069/5f4a1d47-8062-4a7e-b877-dc54c48c80b4)

**FIXED:**
![image](https://github.com/zesty-io/website/assets/70579069/e57e7527-b2a1-473a-b1e4-ba3cd187292e)
![image](https://github.com/zesty-io/website/assets/70579069/1c6d1325-ec1f-425b-9166-be735549972a)

