### PR TITLE
fix: account ui top right search support legacy search

### DIFF
--- a/src/components/accounts/ui/select/AccountsComboBox.js
+++ b/src/components/accounts/ui/select/AccountsComboBox.js
@@ -141,7 +141,7 @@ const StyledPopper = styled(Popper)({
 
 const filterOptions = createFilterOptions({
   matchFrom: 'any',
-  stringify: (option) => option.name + option.value,
+  stringify: (option) => option.name + option.value + option.id,
 });
 
 const Index = ({
@@ -161,6 +161,7 @@ const Index = ({
     return {
       name: e.name,
       value: e.ZUID,
+      id: e.ID,
     };
   });
 

--- a/src/components/console/AccountsAppbar.js
+++ b/src/components/console/AccountsAppbar.js
@@ -93,6 +93,7 @@ export const AccountsAppbar = ({ colorInvert = false }) => {
   if (isDocsPage) {
     return <></>;
   }
+
   return (
     <Box
       width={1}


### PR DESCRIPTION
# Description

Allow Search by Legacy ID inside account ui topbar search

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

![image](https://github.com/zesty-io/website/assets/61284357/d61663a3-dbdf-465e-bd06-a3c8474026e7)


closes https://github.com/zesty-io/website/issues/2347



