### PR TITLE
fix(slashimageherowithcta.js): conditional rendering when cta is avai…

### DIFF
--- a/src/blocks/heroes/SlashImageHeroWithCta/SlashImageHeroWithCta.js
+++ b/src/blocks/heroes/SlashImageHeroWithCta/SlashImageHeroWithCta.js
@@ -109,6 +109,7 @@ const Hero = ({
           </>
         )}
 
+
         <Stack
           sx={{
             display: 'flex',
@@ -126,7 +127,7 @@ const Hero = ({
               {cta_left || FillerContent.cta}
             </Button>
           ) : (
-            <TryFreeButton
+            cta_left && <TryFreeButton
               text={cta_left}
               variant="contained"
               size="large"


### PR DESCRIPTION
# Description

Remove blank CTA button. Mindshare tag page should not contain a CTA button based on the schema structure from the manager.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Screenshots / Screen recording
![image](https://github.com/zesty-io/website/assets/70579069/ffab6c68-345c-42ac-82eb-d4851b80017f)
