### PR TITLE
fix: Standardize Font Style Across All Integration Announcement Pages

### DIFF
--- a/src/components/marketplace/AppInstallerComp.js
+++ b/src/components/marketplace/AppInstallerComp.js
@@ -122,12 +122,12 @@ export const AppInstallerComp = ({ data }) => {
         loading={loading || (isInstalled && selectInstance)}
       >
         {!appSID
-          ? 'Please Login to continue'
+          ? 'Get Started'
           : !instanceZUID
-          ? 'Select an Instance to continue'
+          ? 'Get Started'
           : isInstalled && !selectInstance
           ? `App Installed in ${instanceName}`
-          : `Install  ${data?.name} in ${instanceName}`}
+          : `Get Started`}
       </LoadingButton>
       {isInstalled && (
         <LoadingButton

--- a/src/components/marketplace/ExtensionsIntaller.js
+++ b/src/components/marketplace/ExtensionsIntaller.js
@@ -15,9 +15,7 @@ const ExtensionsIntaller = ({ extensionName, githubUrl, data }) => {
   const { setworkingInstance } = useZestyStore((state) => state);
   const [instances, setinstances] = React.useState([]);
   const instanceZUID = getCookie('ZESTY_WORKING_INSTANCE');
-  const instanceName = instances?.data?.find(
-    (e) => e.ZUID === instanceZUID,
-  )?.name;
+
   let ZestyAPI = useZestyStore((state) => state.ZestyAPI);
 
   // TEMPLATE URL can be access in env files
@@ -171,14 +169,14 @@ const ExtensionsIntaller = ({ extensionName, githubUrl, data }) => {
       loading={loading}
     >
       {!appSID
-        ? 'Please Login To Continue'
+        ? 'Get Started'
         : !instanceZUID
-        ? `Select Instance to continue`
+        ? `Get Started`
         : loading && !finishInstall
         ? `Installing ${extensionName}`
         : !loading && finishInstall
         ? `${extensionName} has been Installed`
-        : `Install ${extensionName} to ${instanceName}`}
+        : `Get Started`}
     </LoadingButton>
   );
 };

--- a/src/components/marketplace/ResourceLinkComp.js
+++ b/src/components/marketplace/ResourceLinkComp.js
@@ -14,7 +14,7 @@ export const ResourceLinkComp = ({ data }) => {
       sx={{ mt: 2 }}
       fullWidth
     >
-      {data?.name}
+      Get Started
     </Button>
   );
 };

--- a/src/views/marketplace/Extension.js
+++ b/src/views/marketplace/Extension.js
@@ -39,7 +39,7 @@ const InstallButton = ({ data, theme }) => {
         color="secondary"
         fullWidth
       >
-        Install {data.name}
+        Get Started
       </Button>
     );
   } else if (data.github_url && !data.app_zuid && !data.resource_link) {
@@ -162,8 +162,11 @@ const Extension = (props) => {
               <Typography
                 variant="h5"
                 component="p"
-                color="text.secondary"
                 mb={1}
+                sx={{
+                  color: theme.palette.zesty.zestyZambezi,
+                  fontWeight: 'bold',
+                }}
               >
                 {props.subtitle}
               </Typography>
@@ -192,9 +195,56 @@ const Extension = (props) => {
                         props: {
                           sx: {
                             color: theme.palette.zesty.zestyZambezi,
+                            marginTop: 2,
                           },
-                          variant: 'h5',
+                          variant: 'h6',
                           component: 'p',
+                        },
+                      },
+                      h4: {
+                        component: Typography,
+                        props: {
+                          sx: {
+                            color: theme.palette.zesty.zestyZambezi,
+                            marginTop: 4,
+                            fontWeight: 'bold',
+                          },
+                          variant: 'h6',
+                          component: 'p',
+                        },
+                      },
+                      h3: {
+                        component: Typography,
+                        props: {
+                          sx: {
+                            color: theme.palette.zesty.zestyZambezi,
+                            marginTop: 4,
+                            fontWeight: 'bold',
+                          },
+                          variant: 'h6',
+                          component: 'p',
+                        },
+                      },
+                      h2: {
+                        component: Typography,
+                        props: {
+                          sx: {
+                            color: theme.palette.zesty.zestyZambezi,
+                            marginTop: 4,
+                            fontWeight: 'bold',
+                          },
+                          variant: 'h6',
+                          component: 'p',
+                        },
+                      },
+                      li: {
+                        component: Typography,
+                        props: {
+                          sx: {
+                            color: theme.palette.zesty.zestyZambezi,
+                          },
+                          variant: 'h6',
+                          component: 'li',
                         },
                       },
                       img: {


### PR DESCRIPTION
# Description

We need to ensure that the font styles on all individual integration announcement pages align with our latest Zesty.io brand guide. Currently the font in every page is inconsistent with our branding guide. 

Fixes #2433 and #2434 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Manual Test

# Screenshots / Screen recording
Before:
![image](https://github.com/zesty-io/website/assets/83058948/58be5af6-c362-4c88-9668-9b0dbdd0edcd)

After:
![image](https://github.com/zesty-io/website/assets/83058948/03bad1b5-1f67-4faa-853f-3dd01d0d3b47)
