### PR TITLE
fix: Add Access Resources component to Freestyle Landing Page (#2453)

### DIFF
--- a/src/components/marketing/Freestyle/FAQs.js
+++ b/src/components/marketing/Freestyle/FAQs.js
@@ -1,37 +1,113 @@
-import React from 'react';
-import Box from '@mui/material/Box';
-import Grid from '@mui/material/Grid';
-import Typography from '@mui/material/Typography';
-import Container from 'components/Container';
+import React, { useState } from 'react';
 
-const FAQs = ({ faqsData }) => {
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Container,
+  Grid,
+  Typography,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import MuiMarkdown from 'markdown-to-jsx';
+
+const FAQs = ({ faqs, title, subtitle }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  const handleChange = (panel) => (event, isExpanded) => {
+    setExpanded(isExpanded ? panel : false);
+  };
+
+  if (!faqs) return null;
   return (
-    <Container>
-      <Box sx={{ px: 4 }}>
-        <Box marginBottom={4}>
-          <Typography fontWeight={700} variant={'h4'} align={'center'}>
-            Frequently asked questions
-          </Typography>
-        </Box>
-        {faqsData.length > 0 && (
-          <Grid container spacing={4}>
-            {faqsData.map((item, i) => (
-              <Grid key={i} item xs={12} sm={6} md={4}>
-                <Typography variant={'h6'} fontWeight={600} gutterBottom>
-                  {item.question}
-                </Typography>
-                <Box
-                  color="text.secondary"
-                  dangerouslySetInnerHTML={{
-                    __html: item.answer,
-                  }}
-                ></Box>
-              </Grid>
-            ))}
+    <Box
+      sx={{
+        width: '100%',
+        margin: 0,
+        padding: 0,
+        py: 10,
+        backgroundColor: '#f9fafb',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      <Container maxWidth={'lg'}>
+        <Grid
+          container
+          direction={{ xs: 'column', md: 'row' }}
+          alignItems={{ xs: 'flex-start', md: 'center' }}
+          mb={5}
+        >
+          <Grid item xs={12} md={6} lg={4}>
+            <Typography
+              sx={{
+                fontSize: { sm: '44px', xs: '36px' },
+                fontWeight: 'bold',
+                textAlign: 'left',
+                lineHeight: '1.2',
+                mb: 2,
+              }}
+            >
+              {title}
+            </Typography>
           </Grid>
-        )}
-      </Box>
-    </Container>
+          <Grid item xs={0} lg={2} />
+          {subtitle !== '' && subtitle && (
+            <Grid item xs={12} md={6} lg={6}>
+              <Typography
+                sx={{
+                  fontSize: { sm: '20px', xs: '18px' },
+                }}
+              >
+                {subtitle}
+              </Typography>
+            </Grid>
+          )}
+        </Grid>
+        <Box sx={{ borderTop: '2.64px solid #181A1D' }}>
+          {faqs.map((faq, index) => (
+            <Accordion
+              key={index}
+              expanded={expanded === `panel${index + 1}`}
+              onChange={handleChange(`panel${index + 1}`)}
+            >
+              <AccordionSummary
+                expandIcon={<ExpandMoreIcon />}
+                aria-controls={`panel${index + 1}a-content`}
+                id={`panel${index + 1}a-header`}
+                sx={{ height: '80px', minHeight: '80px' }}
+              >
+                <Typography
+                  sx={{ fontSize: { xs: '18px', sm: '20px', md: '24px' } }}
+                >
+                  {faq.question}
+                </Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                <MuiMarkdown
+                  options={{
+                    overrides: {
+                      p: {
+                        component: Typography,
+                        props: {
+                          style: {
+                            padding: 0,
+                          },
+                        },
+                      },
+                    },
+                  }}
+                >
+                  {faq.answer}
+                </MuiMarkdown>
+              </AccordionDetails>
+            </Accordion>
+          ))}
+        </Box>
+      </Container>
+    </Box>
   );
 };
 

--- a/src/components/marketing/Freestyle/Hero.js
+++ b/src/components/marketing/Freestyle/Hero.js
@@ -4,11 +4,15 @@ import { useTheme } from '@mui/material/styles';
 import MuiMarkdown from 'markdown-to-jsx';
 import CheckRoundedIcon from '@mui/icons-material/CheckRounded';
 import { useEffect, useState } from 'react';
+import FillerContent from 'components/globals/FillerContent';
+import ZestyImage from 'blocks/Image/ZestyImage';
+import ReactPlayer from 'react-player';
 
 const Hero = ({
   overline = '',
   description,
   heroImage = 'https://kfg6bckb.media.zestyio.com/Hero-Image-2.webp',
+  heroVideo,
   primaryCta = 'Talk to Us',
   primaryCtaLink = '/demo?ab=light',
   secondaryCtaText,
@@ -153,15 +157,36 @@ const Hero = ({
             </Stack>
           </Stack>
         </Grid>
-        <Grid item xs={12} lg={6} sx={{ position: 'relative', zIndex: 1 }}>
-          <img
-            loading="eager"
-            src={heroImage}
-            width="100%"
-            height="100%"
-            alt="Zesty Image"
-            style={{ objectFit: 'contain ' }}
-          />
+        <Grid item xs={12} lg={6}>
+          <Box
+            sx={{
+              position: 'relative',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              iframe: {
+                borderRadius: 5,
+              },
+              width: '100%',
+              height: '100%',
+            }}
+          >
+            {!heroVideo ? (
+              <ZestyImage
+                src={heroImage || FillerContent.image}
+                style={{ width: '100%', height: '100%', objectFit: 'contain' }}
+              />
+            ) : (
+              <ReactPlayer
+                width={'100%'}
+                url={heroVideo || FillerContent.videoUrl}
+                muted={false}
+                playing={false}
+                loop={true}
+                controls={true}
+              />
+            )}
+          </Box>
         </Grid>
       </Grid>
     </Box>

--- a/src/views/zesty/Freestyle.js
+++ b/src/views/zesty/Freestyle.js
@@ -59,6 +59,8 @@ import TechStack from 'components/marketing/Freestyle/TechStack';
 import GetDemoSection from 'revamp/ui/GetDemoSection';
 import FAQs from 'components/marketing/Freestyle/FAQs';
 import FeaturedUseCase from 'components/marketing/Freestyle/FeaturedUseCase';
+import Resources from 'components/marketing/IntegrationsIndividualPage/Resources';
+import { useMediaQuery } from '@mui/material';
 
 const benefitsData = (dataArray) => {
   return (
@@ -95,10 +97,17 @@ const featureUseCaseData = (dataArray) => {
 function Freestyle({ content }) {
   const theme = useTheme();
 
+  const isSmall = useMediaQuery(theme.breakpoints.down('sm'));
+  const isMedium = useMediaQuery(theme.breakpoints.down('md'));
+  const isLarge = useMediaQuery(theme.breakpoints.down('lg'));
+  const isExtraLarge = useMediaQuery(theme.breakpoints.down('xl'));
+  const isDarkMode = theme.palette.mode === 'dark';
+
   const heroProps = {
     overline: content.header_eyebrow,
     description: content.hero_description,
     heroImage: content.header_graphic?.data[0]?.url,
+    heroVideo: content.hero_promo_video,
     primaryCta: content.hero_primary_cta_text || FillerContent.link,
     primaryCtaLink:
       (content.hero_primary_cta_link == 0 && '/join/') ||
@@ -130,12 +139,34 @@ function Freestyle({ content }) {
   const featuredUseCaseProps = {
     title: content.featured_use_cases_title,
     data: featureUseCaseData(content.featured_use_cases),
+    imageWidth: 150,
+  };
+
+  const faqsProps = {
+    faqs: content?.faqs.data,
+    title: content?.faq_title,
+    subtitle: content?.faq_subtitle,
+  };
+
+  const resourcesProps = {
+    theme,
+    isSmall,
+    isMedium,
+    isLarge,
+    isExtraLarge,
+    isDarkMode,
+    content: {
+      resources_title: content?.resources_title,
+      resources_buttons: content?.resources_buttons,
+    },
+    FillerContent,
   };
 
   return (
     <ThemeProvider theme={() => revampTheme(theme.palette.mode)}>
       <Hero {...heroProps} />
       <FeaturedUseCase {...featuredUseCaseProps} />
+      <Resources {...resourcesProps} />
       <UseCase {...useCasesProps} />
       <SimpleCardLogo
         variant="outlined"
@@ -148,7 +179,7 @@ function Freestyle({ content }) {
       {content.integrations_title && content.integration_logos && (
         <TechStack {...integrationProps} />
       )}
-      <FAQs faqsData={content?.faqs.data} />
+      <FAQs {...faqsProps} />
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
# Description

Add Access Resources component to Freestyle Landing Page; Add the new dropdown FAQs component; Make the images in the Freestyle featured use cases section larger; Fixed video isn't displaying correctly.

Fixes #2448, #2449. #2450, #2451

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Manual Test

# Screenshots / Screen recording
Before

![image](https://github.com/zesty-io/website/assets/83058948/26faedf4-c7c9-4ebe-bcc1-24e2e768535d)

After

![image](https://github.com/zesty-io/website/assets/83058948/132ec571-a4f7-4f05-a8d1-060df298c8a2)

