### PR TITLE
fix: Zesty.io Mindshare links falling back to old content/not displaying properly

### DIFF
--- a/src/layouts/Main/Main.js
+++ b/src/layouts/Main/Main.js
@@ -191,6 +191,7 @@ const Main = ({
                 isAuthenticated={isLoggedIn}
                 userInfo={userInfo?.data}
                 loading={loading}
+                cta={'Contact Sales'}
               />
             </Stack>
           )}

--- a/src/lib/ZestyView.js
+++ b/src/lib/ZestyView.js
@@ -46,7 +46,7 @@ export function ZestyView(props) {
         props.content.meta.layout?.json['layout:root:column:0']?.children,
       ) === '{}'
     ) {
-      return true;
+      return false;
     }
 
     // return only true if the layout is active and has components


### PR DESCRIPTION
# Description

Fixed Zesty.io Mindshare links falling back to old content/not displaying properly

Fixes #2463

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Manual Test
- [ ] Unit Test
- [ ] E2E Test

# Screenshots / Screen recording
Before:
![image](https://github.com/zesty-io/website/assets/83058948/a86c3600-4c11-4a84-a665-775085c253d5)

After:
![image](https://github.com/zesty-io/website/assets/83058948/1ae206ce-91cc-4500-b5d2-984d513c3c09)