### PR TITLE
fix: Remove Acorn, BJs and Cornershop logos from all components in the marketing website

### DIFF
--- a/src/revamp/ui/GetDemoSection/index.js
+++ b/src/revamp/ui/GetDemoSection/index.js
@@ -19,9 +19,7 @@ import useGetDynamicData from './useGetDynamicData';
 import { useRouter } from 'next/router';
 import ZestyImage from 'blocks/Image/ZestyImage';
 
-const bjs = `https://storage.googleapis.com/assets.zesty.io/website/images/assets/demo/BJ's%20Logo.svg`,
-  rocketLeague = `https://storage.googleapis.com/assets.zesty.io/website/images/assets/demo/Horizontal_Text.svg`,
-  cornershop = `https://storage.googleapis.com/assets.zesty.io/website/images/assets/demo/Logo_de_Cornershop%201.svg`,
+const rocketLeague = `https://storage.googleapis.com/assets.zesty.io/website/images/assets/demo/Horizontal_Text.svg`,
   phoenixSuns = `https://storage.googleapis.com/assets.zesty.io/website/images/assets/demo/Phoenix%20Suns.svg`,
   singlife = `https://storage.googleapis.com/assets.zesty.io/website/images/assets/demo/Singlife%20Logo.svg`,
   sony = `https://storage.googleapis.com/assets.zesty.io/website/images/assets/demo/Sony%20Logo.svg`,
@@ -382,22 +380,6 @@ export function Logos({ invert = false, alignLeft }) {
           width="115.91px"
           height="32px"
           alt={generateAlt('Wattpad')}
-        />
-        <img
-          style={{ filter: invert ? 'invert(0.5)' : 'none' }}
-          loading="lazy"
-          src={cornershop}
-          width="96.69px"
-          height="32px"
-          alt={generateAlt('Corner Shop')}
-        />
-        <img
-          style={{ filter: invert ? 'invert(0.5)' : 'none' }}
-          loading="lazy"
-          src={bjs}
-          width="36.48px"
-          height="32px"
-          alt={generateAlt('Bjs')}
         />
       </Stack>
     </Stack>

--- a/src/revamp/ui/HeroV2/index.js
+++ b/src/revamp/ui/HeroV2/index.js
@@ -9,8 +9,6 @@ import Logos from './Logos';
 
 const media =
     'https://kfg6bckb.media.zestyio.com/Zesty-io-2023-Homepage-Graphic.webp',
-  acorns = 'https://kfg6bckb.media.zestyio.com/acornsHero.svg',
-  bjs = 'https://kfg6bckb.media.zestyio.com/bjsHero.svg',
   phoenixSuns = 'https://kfg6bckb.media.zestyio.com/phoenixSunsHero.svg',
   rocketLeague = 'https://kfg6bckb.media.zestyio.com/rocketLeagueHero.svg',
   singlife = 'https://kfg6bckb.media.zestyio.com/singlifeHero.svg',
@@ -37,20 +35,6 @@ const logos = [
     height: 32,
     title: 'Singlife',
     alt: generateAlt('Singlife'),
-  },
-  {
-    src: acorns,
-    width: 94,
-    height: 32,
-    title: 'Acorns',
-    alt: generateAlt('Acorns'),
-  },
-  {
-    src: bjs,
-    width: 36.48,
-    height: 32,
-    title: 'Bjs',
-    alt: generateAlt('Bjs'),
   },
   {
     src: phoenixSuns,


### PR DESCRIPTION
# Description

Removed Acorn, BJs and Cornershop logos from all components in the marketing website (Homepage, Demo, Insurance CMS). 

Fixes #2484 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual Test

# Screenshots / Screen recording

![image](https://github.com/user-attachments/assets/6ac7e196-bc3a-4d01-afec-a364f66e1e59)
![image](https://github.com/user-attachments/assets/ee5b6d8c-3c75-466b-93b1-64f4f8b98d8d)
![image](https://github.com/user-attachments/assets/33221a89-a95a-4598-80d9-1b48288bc56a)
