### PR TITLE
fix: Open permissions tab upon successful creation of custom role

### DIFF
--- a/src/components/accounts/roles/CustomRoles.tsx
+++ b/src/components/accounts/roles/CustomRoles.tsx
@@ -19,7 +19,11 @@ import {
   DeleteRounded,
 } from '@mui/icons-material';
 
-import { EditCustomRoleDialog } from './EditCustomRoleDialog';
+import {
+  EditCustomRoleDialog,
+  TabNames,
+  TabName,
+} from './EditCustomRoleDialog';
 import { DeleteCustomRoleDialog } from './DeleteCustomRoleDialog';
 import { Role } from 'store/types';
 
@@ -32,9 +36,13 @@ export const CustomRoles = forwardRef(
     const [ZUIDToEdit, setZUIDToEdit] = useState<string>(null);
     const [ZUIDToDelete, setZUIDToDelete] = useState<string>(null);
     const [activeZUID, setActiveZUID] = useState<string>(null);
+    const [tabToOpen, setTabToOpen] = useState<TabName>(TabNames.details);
 
     useImperativeHandle(ref, () => ({
-      updateZUIDToEdit: (ZUID: string) => setZUIDToEdit(ZUID),
+      updateZUIDToEdit: (ZUID: string) => {
+        setZUIDToEdit(ZUID);
+        setTabToOpen(TabNames.permissions);
+      },
     }));
 
     return (
@@ -57,6 +65,7 @@ export const CustomRoles = forwardRef(
                   }}
                   onClick={() => {
                     setZUIDToEdit(role.ZUID);
+                    setTabToOpen(TabNames.details);
                   }}
                 >
                   <ListItemAvatar>
@@ -107,6 +116,7 @@ export const CustomRoles = forwardRef(
                     onClick={() => {
                       setAnchorEl(null);
                       setZUIDToEdit(role.ZUID);
+                      setTabToOpen(TabNames.details);
                     }}
                   >
                     <ListItemIcon>
@@ -134,6 +144,7 @@ export const CustomRoles = forwardRef(
           <EditCustomRoleDialog
             ZUID={ZUIDToEdit}
             onClose={() => setZUIDToEdit(null)}
+            tabToOpen={tabToOpen}
           />
         )}
         {!!ZUIDToDelete && (

--- a/src/components/accounts/roles/EditCustomRoleDialog/index.tsx
+++ b/src/components/accounts/roles/EditCustomRoleDialog/index.tsx
@@ -58,7 +58,7 @@ type EditCustomRoleDialogProps = {
 export const EditCustomRoleDialog = ({
   ZUID,
   onClose,
-  tabToOpen = 'details',
+  tabToOpen = TabNames.details,
 }: EditCustomRoleDialogProps) => {
   const router = useRouter();
   const { ZestyAPI } = useZestyStore((state: any) => state);

--- a/src/components/accounts/roles/EditCustomRoleDialog/index.tsx
+++ b/src/components/accounts/roles/EditCustomRoleDialog/index.tsx
@@ -30,6 +30,12 @@ import { GranularRole } from 'store/types';
 import { useZestyStore } from 'store';
 import { ErrorMsg } from 'components/accounts/ui';
 
+export const TabNames = {
+  details: 'details',
+  permissions: 'permissions',
+  users: 'users',
+} as const;
+export type TabName = (typeof TabNames)[keyof typeof TabNames];
 type FieldErrors = {
   detailsTab: {
     roleName: string;
@@ -47,10 +53,12 @@ export type RoleDetails = {
 type EditCustomRoleDialogProps = {
   ZUID: string;
   onClose: () => void;
+  tabToOpen?: TabName;
 };
 export const EditCustomRoleDialog = ({
   ZUID,
   onClose,
+  tabToOpen = 'details',
 }: EditCustomRoleDialogProps) => {
   const router = useRouter();
   const { ZestyAPI } = useZestyStore((state: any) => state);
@@ -66,9 +74,7 @@ export const EditCustomRoleDialog = ({
     updateUserRole,
     getUsersWithRoles,
   } = useRoles((state) => state);
-  const [activeTab, setActiveTab] = useState<
-    'details' | 'permissions' | 'users'
-  >('details');
+  const [activeTab, setActiveTab] = useState<TabName>(tabToOpen);
   const [isSaving, setIsSaving] = useState(false);
   const [fieldErrors, updateFieldErrors] = useReducer(
     (
@@ -395,7 +401,7 @@ export const EditCustomRoleDialog = ({
           bgcolor: 'grey.50',
         }}
       >
-        {activeTab === 'details' && (
+        {activeTab === TabNames.details && (
           <Details
             data={detailsData}
             onUpdateData={(data) => {
@@ -413,7 +419,7 @@ export const EditCustomRoleDialog = ({
             errors={fieldErrors.detailsTab}
           />
         )}
-        {activeTab === 'permissions' && (
+        {activeTab === TabNames.permissions && (
           <Permissions
             granularRoles={granularRoles}
             onAddNewGranularRole={(newRoleData) => {
@@ -465,7 +471,7 @@ export const EditCustomRoleDialog = ({
             }}
           />
         )}
-        {activeTab === 'users' && (
+        {activeTab === TabNames.users && (
           <Users
             userEmails={userEmails}
             onUpdateUserEmails={(emails) => setUserEmails(emails)}

--- a/src/components/accounts/roles/EditCustomRoleDialog/tabs/Permissions/Table.tsx
+++ b/src/components/accounts/roles/EditCustomRoleDialog/tabs/Permissions/Table.tsx
@@ -55,7 +55,7 @@ export const Table = ({
             defaultChecked={!!params.value}
             onChange={(evt) =>
               onDataChange({
-                resourceZUID: params.row?.resourceZUID,
+                resourceZUID: params.row?.id,
                 create: evt.target.checked,
               })
             }
@@ -71,7 +71,7 @@ export const Table = ({
             defaultChecked={!!params.value}
             onChange={(evt) =>
               onDataChange({
-                resourceZUID: params.row?.resourceZUID,
+                resourceZUID: params.row?.id,
                 read: evt.target.checked,
               })
             }
@@ -87,7 +87,7 @@ export const Table = ({
             defaultChecked={!!params.value}
             onChange={(evt) =>
               onDataChange({
-                resourceZUID: params.row?.resourceZUID,
+                resourceZUID: params.row?.id,
                 update: evt.target.checked,
               })
             }
@@ -103,7 +103,7 @@ export const Table = ({
             defaultChecked={!!params.value}
             onChange={(evt) =>
               onDataChange({
-                resourceZUID: params.row?.resourceZUID,
+                resourceZUID: params.row?.id,
                 delete: evt.target.checked,
               })
             }
@@ -119,7 +119,7 @@ export const Table = ({
             defaultChecked={!!params.value}
             onChange={(evt) =>
               onDataChange({
-                resourceZUID: params.row?.resourceZUID,
+                resourceZUID: params.row?.id,
                 publish: evt.target.checked,
               })
             }


### PR DESCRIPTION
# Description

Automatically opens the permissions tab upon successful creation of a new custom role


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
- [x] Manual Test

# Screenshots / Screen recording
[screen-recorder-tue-dec-10-2024-09-28-21.webm](https://github.com/user-attachments/assets/95d107ee-a993-4824-b553-1fce444c8cdc)

