### PR TITLE
feat: Add redirect for Zesty documentation to new URL (#2506)

### DIFF
--- a/src/config/redirects.js
+++ b/src/config/redirects.js
@@ -1,5 +1,10 @@
 const docsRedirects = [
   {
+    source: '/docs/',
+    destination: 'https://docs.zesty.io/',
+    permanent: true,
+  },
+  {
     source: '/docs/instances/api-reference/:path*',
     destination: 'https://docs.zesty.io/reference/instances-api-reference',
     permanent: true,


### PR DESCRIPTION
# Description

Added a new redirect from '/docs/' to 'https://docs.zesty.io/'.

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Manual Test

# Screenshots / Screen recording

https://github.com/user-attachments/assets/8864f515-290e-4824-bb89-312155f940cf
