### PR TITLE
fix: allow users with a systemRole.grant = true to update user roles

### DIFF
--- a/src/pages/instances/[zuid]/users.js
+++ b/src/pages/instances/[zuid]/users.js
@@ -144,8 +144,6 @@ export default function UsersPage() {
 
     const updateUsersPermission = instanceUserWithRoles.find(
       (user) => user.ZUID === userInfo.ZUID,
-    const updateUsersPermission = instanceUserWithRoles.find(
-      (user) => user.ZUID === userInfo.ZUID,
     )?.role?.systemRole?.grant;
 
     return updateUsersPermission || userInfo.staff;

--- a/src/pages/instances/[zuid]/users.js
+++ b/src/pages/instances/[zuid]/users.js
@@ -144,7 +144,9 @@ export default function UsersPage() {
 
     const updateUsersPermission = instanceUserWithRoles.find(
       (user) => user.ZUID === userInfo.ZUID,
-    )?.role.systemRole.grant;
+    const updateUsersPermission = instanceUserWithRoles.find(
+      (user) => user.ZUID === userInfo.ZUID,
+    )?.role?.systemRole?.grant;
 
     return updateUsersPermission || userInfo.staff;
   }, [instanceUserWithRoles, userInfo]);

--- a/src/pages/instances/[zuid]/users.js
+++ b/src/pages/instances/[zuid]/users.js
@@ -3,7 +3,6 @@ import { useZestyStore } from 'store';
 import { useRouter } from 'next/router';
 import { Users } from 'views/accounts';
 import { ErrorMsg, SuccessMsg } from 'components/accounts';
-import * as helpers from 'utils';
 import InstanceContainer from 'components/accounts/instances/InstanceContainer';
 
 export { default as getServerSideProps } from 'lib/accounts/protectedRouteGetServerSideProps';
@@ -138,10 +137,17 @@ export default function UsersPage() {
     }
   }, [router.isReady]);
 
-  const isInstanceOwner = helpers.isInstanceOwner(
-    instanceUserWithRoles,
-    userInfo,
-  );
+  const canUpdateUsers = React.useMemo(() => {
+    if (!userInfo || !instanceUserWithRoles?.length) {
+      return false;
+    }
+
+    const updateUsersPermission = instanceUserWithRoles.find(
+      (user) => user.ZUID === userInfo.ZUID,
+    )?.role.systemRole.grant;
+
+    return updateUsersPermission || userInfo.staff;
+  }, [instanceUserWithRoles, userInfo]);
 
   const filteredUsers = instanceUserWithRoles?.filter((e) => {
     const name = `${e?.firstName?.toLowerCase() || '-'} ${
@@ -155,7 +161,7 @@ export default function UsersPage() {
     deleteUserRole,
     instanceRoles,
     createInvite,
-    isOwner: isInstanceOwner,
+    canUpdateUsers,
     instanceZUID: zuid,
     loading,
     search,

--- a/src/views/accounts/instances/Users.js
+++ b/src/views/accounts/instances/Users.js
@@ -51,7 +51,7 @@ const CustomTable = ({
   handleUpdateRole,
   handleDeleteRole,
   instanceRoles,
-  isOwner,
+  canUpdateUsers,
   loading,
 }) => {
   const ROWS = data?.map((e) => {
@@ -120,7 +120,7 @@ const CustomTable = ({
           handleUpdateRole(val);
         };
 
-        const role = isOwner
+        const role = canUpdateUsers
           ? RoleSwitcher({
               role: e.role.name,
               handleOnChange,
@@ -189,7 +189,10 @@ const CustomTable = ({
           },
         ];
         const actionOwner = [
-          { title: 'Delete User', action: isOwner ? handleDeleteUser : null },
+          {
+            title: 'Delete User',
+            action: canUpdateUsers ? handleDeleteUser : null,
+          },
           {
             title: 'Email',
             action: () => window.open(`mailto:${params.row.email}`),
@@ -205,7 +208,7 @@ const CustomTable = ({
                 </Button>
               }
               id={'actions'}
-              items={isOwner ? actionOwner : action}
+              items={canUpdateUsers ? actionOwner : action}
               colorInvert={false}
             />
           </>
@@ -276,7 +279,7 @@ const Index = ({
   deleteUserRole,
   instanceRoles,
   createInvite,
-  isOwner,
+  canUpdateUsers,
   instanceZUID,
   loading,
   search,
@@ -347,7 +350,7 @@ const Index = ({
           handleUpdateRole={handleUpdateRole}
           handleDeleteRole={handleDeleteRole}
           instanceRoles={instanceRoles}
-          isOwner={isOwner}
+          canUpdateUsers={canUpdateUsers}
           loading={loading}
         />
       </Grid>
@@ -357,7 +360,7 @@ const Index = ({
           data={pendingUsers}
           instanceRoles={instanceRoles}
           respondToInvite={respondToInvite}
-          isOwner={isOwner}
+          canUpdateUsers={canUpdateUsers}
           loading={loading}
         />
       </Grid>
@@ -369,7 +372,7 @@ export const Users = React.memo(Index);
 const PendingTable = ({
   data,
   instanceRoles,
-  // isOwner,
+  // canUpdateUsers,
   loading,
   respondToInvite,
 }) => {


### PR DESCRIPTION
# Description

Allows users with a systemRole.grant = true to update user roles. Originally it only allows users with a role name of Admin or Owner which makes it not flexible and doesn't take into consideration created custom roles.

Fixes #2514 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Manual Test
- [ ] Unit Test
- [ ] E2E Test

# Screenshots / Screen recording
[Screencast_20251111_100718.webm](https://github.com/user-attachments/assets/b6c0f6d2-8321-49b4-8852-b0af9868df02)

