### PR TITLE
fix: Add cancel button to invite user modal

### DIFF
--- a/src/views/accounts/instances/Users.js
+++ b/src/views/accounts/instances/Users.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
-import { Box, Button, Grid, Stack, Typography } from '@mui/material';
+import { Box, Button, Grid, Stack, Typography, useTheme } from '@mui/material';
 import {
   accountsValidations,
   FormInput,
@@ -12,6 +12,7 @@ import {
   AccountsTableHead,
 } from 'components/accounts';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
+import { grey } from '@mui/material/colors';
 
 import AddIcon from '@mui/icons-material/Add';
 import { baseroles } from 'components/accounts/users/baseroles';
@@ -230,7 +231,9 @@ const CustomTable = ({
   );
 };
 
-const CustomForm = ({ onSubmit, options, instanceZUID }) => {
+const CustomForm = ({ onSubmit, options, instanceZUID, onCancel }) => {
+  const theme = useTheme();
+
   const formik = useFormik({
     validationSchema: accountsValidations.email,
     initialValues: {
@@ -265,7 +268,28 @@ const CustomForm = ({ onSubmit, options, instanceZUID }) => {
           formik={formik}
           options={newOptions}
         />
-        <SubmitBtn loading={formik.isSubmitting}>Submit</SubmitBtn>
+        <Stack gap={1}>
+          <SubmitBtn loading={formik.isSubmitting}>Submit</SubmitBtn>
+          <Button
+            color={theme.palette.mode === 'light' ? 'inherit' : 'primary'}
+            variant="outlined"
+            fullWidth
+            disabled={formik.isSubmitting}
+            onClick={onCancel}
+            sx={(theme) => ({
+              textTransform: 'none',
+              border:
+                theme.palette.mode === 'light' && `1px solid ${grey[200]}`,
+              bgcolor: theme.palette.mode === 'light' && 'white',
+              '&:hover': {
+                bgcolor: theme.palette.mode === 'light' && 'white',
+                color: theme.palette.mode === 'light' && 'black',
+              },
+            })}
+          >
+            Cancel
+          </Button>
+        </Stack>
       </form>
     </Box>
   );
@@ -299,6 +323,7 @@ const Index = ({
           onSubmit={createInvite}
           options={options}
           instanceZUID={instanceZUID}
+          onCancel={() => MySwal.close()}
         />
       ),
       showConfirmButton: false,

--- a/src/views/accounts/instances/Users.js
+++ b/src/views/accounts/instances/Users.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
-import { Box, Button, Grid, Stack, Typography, useTheme } from '@mui/material';
+import { Box, Button, Grid, Stack, Typography } from '@mui/material';
 import {
   accountsValidations,
   FormInput,
@@ -232,8 +232,6 @@ const CustomTable = ({
 };
 
 const CustomForm = ({ onSubmit, options, instanceZUID, onCancel }) => {
-  const theme = useTheme();
-
   const formik = useFormik({
     validationSchema: accountsValidations.email,
     initialValues: {
@@ -271,21 +269,20 @@ const CustomForm = ({ onSubmit, options, instanceZUID, onCancel }) => {
         <Stack gap={1}>
           <SubmitBtn loading={formik.isSubmitting}>Submit</SubmitBtn>
           <Button
-            color={theme.palette.mode === 'light' ? 'inherit' : 'primary'}
+            color="inherit"
             variant="outlined"
             fullWidth
             disabled={formik.isSubmitting}
             onClick={onCancel}
-            sx={(theme) => ({
+            sx={{
               textTransform: 'none',
-              border:
-                theme.palette.mode === 'light' && `1px solid ${grey[200]}`,
-              bgcolor: theme.palette.mode === 'light' && 'white',
+              border: `1px solid ${grey[200]}`,
+              bgcolor: 'white',
               '&:hover': {
-                bgcolor: theme.palette.mode === 'light' && 'white',
-                color: theme.palette.mode === 'light' && 'black',
+                bgcolor: 'white',
+                color: 'black',
               },
-            })}
+            }}
           >
             Cancel
           </Button>
@@ -323,7 +320,7 @@ const Index = ({
           onSubmit={createInvite}
           options={options}
           instanceZUID={instanceZUID}
-          onCancel={() => MySwal.close()}
+          onCancel={MySwal.close}
         />
       ),
       showConfirmButton: false,

--- a/src/views/accounts/instances/Users.js
+++ b/src/views/accounts/instances/Users.js
@@ -269,6 +269,7 @@ const CustomForm = ({ onSubmit, options, instanceZUID, onCancel }) => {
         <Stack gap={1}>
           <SubmitBtn loading={formik.isSubmitting}>Submit</SubmitBtn>
           <Button
+            type="button"
             color="inherit"
             variant="outlined"
             fullWidth


### PR DESCRIPTION
Resolves #2521

## Summary
- Added a Cancel button to the `CustomForm` component inside the Invite User modal in the Accounts Users view
- Wired the button to close the SweetAlert2 modal via `MySwal.close()`, giving users a way to dismiss the dialog without submitting

## Test plan
- [ ] Navigate to an instance's Users page in the Accounts UI
- [ ] Click the invite user button to open the modal
- [ ] Verify the Cancel button appears below the Submit button
- [ ] Click Cancel and confirm the modal closes without sending an invite
- [ ] Verify the Cancel button is disabled while the form is submitting
- [ ] Check appearance in both light and dark mode

## Preview

<img width="554" height="484" alt="Screenshot_20260608_094625" src="https://github.com/user-attachments/assets/87e6a8fd-9dbd-48ec-ad85-f7f2225a1cca" />

