### PR TITLE
fix: stop 404s/redirects from being publicly CDN-cached

### DIFF
--- a/src/pages/[[...zesty]].js
+++ b/src/pages/[[...zesty]].js
@@ -75,17 +75,11 @@ export async function getServerSideProps({ req, res, resolvedUrl }) {
   // does not display with npm run dev
 
   res.setHeader('set-cookie', `PRODUCTION=${process.env.PRODUCTION}`);
-  isProd &&
-    res.setHeader(
-      'Cache-Control',
-      'public, max-age=3600, stale-while-revalidate=7200 ',
-    );
-  isProd && res.setHeader('Surrogate-Control', 'max-age=3600');
 
-  res.setHeader(
-    'Surrogate-Key',
-    `${process.env.zesty.instance_zuid}, zesty.io`,
-  );
+  // Default to non-cacheable; cache headers are set only on the 200 path below
+  // so 404s/redirects can't be pinned at the CDN edge and served to everyone.
+  res.setHeader('Cache-Control', 'private, no-store');
+
   // Fetch the page data using the cache function
   let data = await fetchPage(resolvedUrl);
   // attempt to get page data relative to zesty
@@ -158,6 +152,19 @@ export async function getServerSideProps({ req, res, resolvedUrl }) {
         permanent: false,
       },
     };
+  }
+
+  // Real 200 page: safe to cache and tag with the instance Surrogate-Key.
+  if (isProd) {
+    res.setHeader(
+      'Cache-Control',
+      'public, max-age=3600, stale-while-revalidate=7200',
+    );
+    res.setHeader('Surrogate-Control', 'max-age=3600');
+    res.setHeader(
+      'Surrogate-Key',
+      `${process.env.zesty.instance_zuid}, zesty.io`,
+    );
   }
 
   // Pass data to the page via props


### PR DESCRIPTION
`https://www.zesty.io/instances/` returned a 404 served from the Fastly edge to everyone and only a manual "refresh the marketing instance CDN" cleared it.

 Root cause: a `Surrogate-Control` header on a non-200 response

The main header responsible for this is `Surrogate-Control`, not `Cache-Control`. On Fastly, `Surrogate-Control` controls the shared edge cache and overrides `Cache-Control`

In the catch-all `src/pages/[[...zesty]].js`, `getServerSideProps` set all three caching headers at the top of the function, before knowing the outcome

When `/instances/` briefly 404'd through this catch-all, the 404 went out carrying `Surrogate-Control: max-age=3600`. 

Next.js technically overrides `Cache-Control` to `no-store, must-revalidate` on that notFound response  but that did nothing, because Next only touches `Cache-Control` (browser). It has no idea `Surrogate-Control`/`Surrogate-Key` exist, so it left them on the response. 

Fastly saw `Surrogate-Control: max-age=3600`, ignored the `no-store`, and cached the 404 at the edge.
 
`Surrogate-Key: <instance_zuid>` tagged it under the marketing instance's key, so it took a full instance purge to clear (and was served to everyone until then).

I want to note that (`Cache-Control`) was a red herring here for me. The bug was entirely `Surrogate-Control` being present on a response that turned out to be a 404.