### PR TITLE
fix: my apps link 404 in production

### DIFF
--- a/src/components/marketplace/installed/index.js
+++ b/src/components/marketplace/installed/index.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { getCookie } from 'cookies-next';
 import BasicTable from './table';
 import { Box, CircularProgress, Typography } from '@mui/material';
 import TransitionsModal from 'blocks/modal/modal';
@@ -20,7 +19,7 @@ const index = () => {
   const [success, setsucces] = React.useState('');
   const [loading, setloading] = React.useState(false);
   const [installedApps, setinstalledApps] = React.useState([]);
-  const instanceZUID = getCookie('ZESTY_WORKING_INSTANCE');
+  const instanceZUID = useZestyStore((state) => state.workingInstance);
 
   const ZestyAPI = useZestyStore((state) => state.ZestyAPI);
   const getInstalledAppSuccess = (res) => {

--- a/src/components/marketplace/register/index.js
+++ b/src/components/marketplace/register/index.js
@@ -9,7 +9,6 @@ import {
 import CircularProgress from '@mui/material/CircularProgress';
 import React from 'react';
 import { useFormik } from 'formik';
-import { getCookie } from 'cookies-next';
 import * as yup from 'yup';
 import TransitionsModal from '../../../blocks/modal/modal';
 import { useFetchWrapper } from 'components/hooks/useFetchWrapper';
@@ -191,11 +190,11 @@ const customContainer = {
 const RegisterPage = ({}) => {
   const theme = useTheme();
 
-  const instanceZUID = getCookie('ZESTY_WORKING_INSTANCE');
   const userAppSID = getUserAppSID();
   const isLoggedIn = useIsLoggedIn();
 
   const ZestyAPI = useZestyStore((state) => state.ZestyAPI);
+  const instanceZUID = useZestyStore((state) => state.workingInstance);
   const { verifySuccess, loading: verifyLoading } = useFetchWrapper(isLoggedIn);
   const FormProps = {
     ZestyAPI,

--- a/src/pages/marketplace/[...slug].js
+++ b/src/pages/marketplace/[...slug].js
@@ -5,12 +5,20 @@ import { fetchPage, fetcher } from 'lib/api';
 import Extension from 'views/marketplace/Extension';
 import CustomContainer from 'components/Container';
 import Head from 'next/head';
-import RegisterPage from 'components/marketplace/register';
-import InstalledPage from 'components/marketplace/installed';
+import dynamic from 'next/dynamic';
 import { setCookie } from 'cookies-next';
 import MainApps from 'components/marketplace/landing/MainApps';
-import { useEffect, useState } from 'react';
 import { getIsAuthenticated } from 'utils';
+
+// these read cookies directly during render (no SSR guard), so they must
+// stay client-only or their server output mismatches the client hydration
+const RegisterPage = dynamic(() => import('components/marketplace/register'), {
+  ssr: false,
+});
+const InstalledPage = dynamic(
+  () => import('components/marketplace/installed'),
+  { ssr: false },
+);
 
 const ALTNAME = {
   TAG: 'Tag',
@@ -18,16 +26,17 @@ const ALTNAME = {
   EXTENSION: 'Extension',
 };
 
-const slug = ({ marketEntityTypes, marketTags, ...props }) => {
-  const [pathname, setPathname] = useState('');
+const slug = ({
+  marketEntityTypes,
+  marketTags,
+  isRegisterPage,
+  isInstalledPage,
+  ...props
+}) => {
   const seoTitle = props?.meta?.web?.seo_meta_title,
     seoDescription = props?.meta?.web?.seo_meta_description;
 
-  useEffect(() => {
-    setPathname(window.location.pathname);
-  }, []);
-
-  if (pathname === '/marketplace/register/') {
+  if (isRegisterPage) {
     return (
       <>
         <Head>
@@ -47,7 +56,7 @@ const slug = ({ marketEntityTypes, marketTags, ...props }) => {
     );
   }
 
-  if (pathname === '/marketplace/installed/') {
+  if (isInstalledPage) {
     return (
       <>
         <Head>
@@ -148,7 +157,7 @@ export const getMarketplaceData = async (url) => {
   return data;
 };
 
-export async function getServerSideProps({ req, res }) {
+export async function getServerSideProps({ req, res, query }) {
   const isAuthenticated = getIsAuthenticated(res);
 
   res.setHeader(
@@ -180,9 +189,13 @@ export async function getServerSideProps({ req, res }) {
   const navigationCustom = (await fetchPage('/')).navigationCustom;
   const flyoutNavigation = (await fetchPage('/')).flyoutNavigation;
 
-  // partial fix for register page not rendering
-  const isRegisterPage = req.url === '/marketplace/register/';
-  const isInstalledPage = req.url === '/marketplace/installed/';
+  // resolved from the catch-all route params, not req.url, so it stays correct
+  // behind proxies/CDNs that may add query strings or rewrite the request URL
+  const slugSegments = query?.slug || [];
+  const isRegisterPage =
+    slugSegments.length === 1 && slugSegments[0] === 'register';
+  const isInstalledPage =
+    slugSegments.length === 1 && slugSegments[0] === 'installed';
   const extendedPages = isRegisterPage || isInstalledPage;
   // generate a status 404 page
   if (data?.error && !extendedPages) return { notFound: true };
@@ -197,6 +210,8 @@ export async function getServerSideProps({ req, res }) {
       marketTags: tags,
       navigationCustom: navigationCustom,
       flyoutNavigation: flyoutNavigation,
+      isRegisterPage,
+      isInstalledPage,
       zesty: {
         isAuthenticated,
         templateUrl: process.env.TEMPLATE_URL,

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,7 +4,8 @@ import { create } from 'zustand';
 
 const getInstanceZUID = () => {
   if (typeof window !== 'undefined') {
-    return window?.location?.pathname?.split('/')[2];
+    const segments = window.location.pathname.split('/');
+    return segments[1] === 'instances' ? segments[2] : undefined;
   }
 };
 const instanceZUID = getCookie('ZESTY_WORKING_INSTANCE') || getInstanceZUID();


### PR DESCRIPTION
Resolves #2524

## Summary
- Replaced the fragile `req.url` exact-match (used to detect the virtual `/marketplace/register/` and `/marketplace/installed/` pages) with a check on the catch-all route's own `query.slug`, since `req.url` could be altered by the production reverse proxy/CDN in a way local dev never hit — this was the root cause of the 404 in production.
- Rendered `RegisterPage`/`InstalledPage` client-only (`next/dynamic`, `ssr: false`) since both read `getCookie('ZESTY_WORKING_INSTANCE')` directly during render, which caused SSR/CSR hydration mismatches once the page stopped 404ing.
- Switched the installed/register pages to read the working instance from the Zustand store (`useZestyStore((state) => state.workingInstance)`) instead of the cookie directly, so they update reactively when the instance switcher changes it, without requiring a manual page refresh.
- Fixed a regression surfaced by the above in `src/store/index.js`: `getInstanceZUID()`'s fallback treated any URL's third path segment as an instance ZUID, which produced a bogus truthy value (`"installed"`) on `/marketplace/installed/` when no instance was actually selected. Scoped the fallback to `/instances/{zuid}/...` routes only.

## Test plan
- [ ] In production (or a build with a proxy in front), click Accounts UI > Marketplace > My Apps and confirm it loads instead of 404ing.
- [ ] Load `/marketplace/installed/` and `/marketplace/register/` directly and confirm no hydration mismatch warnings in the console.
- [ ] With an instance already selected, switch instances via the instance switcher while on `/marketplace/installed/` and confirm the installed apps list updates without a manual refresh.
- [ ] With no instance selected, load `/marketplace/installed/` and confirm it shows "Please Select an Instance to Continue" rather than "No Data".

## Screenshots

https://github.com/user-attachments/assets/0f7f8275-453b-46c1-acc5-ec9702cec4f0

